### PR TITLE
feat: add subdomain toggle for custom domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/macOS-13%2B-blue" alt="macOS 13+">
   <img src="https://img.shields.io/badge/Swift-5.9-orange" alt="Swift 5.9">
-  <a href="https://github.com/GeiserX/vpn-macos-bypass/releases"><img src="https://img.shields.io/badge/version-1.6.10-green" alt="Version"></a>
+  <a href="https://github.com/GeiserX/vpn-macos-bypass/releases"><img src="https://img.shields.io/badge/version-1.6.11-green" alt="Version"></a>
 </p>
 
 ## Why?

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to VPN Bypass will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.11] - 2026-02-05
+
+### Added
+- **Subdomain Toggle** - New "Include www. subdomain" toggle when adding custom domains
+  - Automatically adds routes for both `example.com` and `www.example.com`
+  - Prevents common issue where sites redirect to www but only the bare domain was bypassed
+  - Default ON for new domains, with visual indicator (+www badge) in domain list
+- **Better URL Cleaning** - Improved domain input parsing
+  - Strips any protocol scheme (not just http/https, now also handles ssh://, ftp://, etc.)
+  - Removes port numbers and authentication info from pasted URLs
+  - Handles more edge cases when pasting full URLs
+
 ## [1.6.10] - 2026-01-29
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Add "Include www. subdomain" toggle when adding custom domains
- Automatically routes both `example.com` and `www.example.com`
- Prevents issue where sites redirect to www but only bare domain was bypassed
- Show +www badge indicator in domain list for domains with subdomains enabled
- Improve URL cleaning to strip any protocol scheme, ports, and auth info

## Test plan

- [ ] Add a new domain (e.g., myanonamouse.net) with subdomain toggle ON
- [ ] Verify both domain and www.domain get routes when VPN connects
- [ ] Verify +www badge appears in domain list
- [ ] Test pasting URLs like `https://example.com/path?query=1` - should extract just `example.com`
- [ ] Test backward compatibility with existing config (old domains should still work)