### PR TITLE
feat: add Check Point VPN detection, fix Homebrew tap and stale URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📖 Documentation
-    url: https://github.com/GeiserX/vpn-macos-bypass#readme
+    url: https://github.com/GeiserX/VPN-Bypass#readme
     about: Check the README for setup instructions and configuration options
   - name: 🗺️ Roadmap
-    url: https://github.com/GeiserX/vpn-macos-bypass/blob/main/ROADMAP.md
+    url: https://github.com/GeiserX/VPN-Bypass/blob/main/ROADMAP.md
     about: See planned features before requesting
   - name: 🍺 Homebrew Installation
     url: https://github.com/GeiserX/homebrew-vpn-bypass

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for suggesting a feature! Please check the [Roadmap](https://github.com/GeiserX/vpn-macos-bypass/blob/main/ROADMAP.md) first to see if it's already planned.
+        Thanks for suggesting a feature! Please check the [Roadmap](https://github.com/GeiserX/VPN-Bypass/blob/main/ROADMAP.md) first to see if it's already planned.
 
   - type: dropdown
     id: category

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -58,7 +58,7 @@ body:
     attributes:
       label: Checklist
       options:
-        - label: I have read the [README](https://github.com/GeiserX/vpn-macos-bypass#readme)
+        - label: I have read the [README](https://github.com/GeiserX/VPN-Bypass#readme)
           required: true
         - label: I have searched existing issues for similar questions
           required: true

--- a/Casks/vpn-bypass.rb
+++ b/Casks/vpn-bypass.rb
@@ -1,5 +1,5 @@
 # Homebrew Cask for VPN Bypass
-# Install: brew install --cask geiserx/tap/vpn-bypass
+# Install: brew install --cask geiserx/vpn-bypass/vpn-bypass
 # Or if using local tap: brew install --cask --no-quarantine ./Casks/vpn-bypass.rb
 
 cask "vpn-bypass" do

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/macOS-13%2B-blue" alt="macOS 13+">
   <img src="https://img.shields.io/badge/Swift-5.9-orange" alt="Swift 5.9">
-  <a href="https://github.com/GeiserX/vpn-macos-bypass/releases"><img src="https://img.shields.io/badge/version-1.6.11-green" alt="Version"></a>
+  <a href="https://github.com/GeiserX/VPN-Bypass/releases"><img src="https://img.shields.io/badge/version-1.6.11-green" alt="Version"></a>
 </p>
 
 ## Why?
@@ -58,7 +58,7 @@ VPN Bypass intelligently routes selected services directly to the internet while
 
 ```bash
 # Add the tap (first time only)
-brew tap geiserx/tap
+brew tap geiserx/vpn-bypass
 
 # Install VPN Bypass
 brew install --cask vpn-bypass
@@ -67,19 +67,19 @@ brew install --cask vpn-bypass
 Or install directly from the repository:
 
 ```bash
-brew install --cask --no-quarantine https://raw.githubusercontent.com/GeiserX/vpn-macos-bypass/main/Casks/vpn-bypass.rb
+brew install --cask --no-quarantine https://raw.githubusercontent.com/GeiserX/VPN-Bypass/main/Casks/vpn-bypass.rb
 ```
 
 ### Manual Download
 
-Download the latest `.dmg` from [Releases](https://github.com/GeiserX/vpn-macos-bypass/releases), open it, and drag **VPN Bypass** to your Applications folder.
+Download the latest `.dmg` from [Releases](https://github.com/GeiserX/VPN-Bypass/releases), open it, and drag **VPN Bypass** to your Applications folder.
 
 ### Build from Source
 
 ```bash
 # Clone the repository
-git clone https://github.com/GeiserX/vpn-macos-bypass.git
-cd vpn-macos-bypass
+git clone https://github.com/GeiserX/VPN-Bypass.git
+cd VPN-Bypass
 
 # Build and create release DMG
 make release
@@ -141,6 +141,7 @@ Click the gear icon to access settings:
 | Zscaler | ✅ Full |
 | Cloudflare WARP | ✅ Full |
 | Pulse Secure | ✅ Full |
+| Check Point | ✅ Full |
 | Tailscale (exit node) | ✅ Full |
 | Tailscale (mesh only) | ❌ Not VPN |
 

--- a/Sources/RouteManager.swift
+++ b/Sources/RouteManager.swift
@@ -69,6 +69,7 @@ final class RouteManager: ObservableObject {
         case cloudflareWARP = "Cloudflare WARP"
         case paloAlto = "Palo Alto"
         case pulseSecure = "Pulse Secure"
+        case checkPoint = "Check Point"
         case unknown = "Unknown VPN"
         
         var icon: String {
@@ -82,6 +83,7 @@ final class RouteManager: ObservableObject {
             case .zscaler: return "cloud.fill"
             case .cloudflareWARP: return "cloud.bolt.fill"
             case .pulseSecure: return "bolt.shield.fill"
+            case .checkPoint: return "checkmark.shield.fill"
             case .unknown: return "shield.fill"
             }
         }
@@ -647,6 +649,10 @@ final class RouteManager: ObservableObject {
         }
         if output.contains("pulsesecure") || output.contains("dsaccessservice") || output.contains("pulseuisvc") {
             return .pulseSecure
+        }
+        if output.contains("endpoint_security_vpn") || output.contains("tracsrvwrapper") ||
+           output.contains("cpdaapp") || output.contains("cpefrd") {
+            return .checkPoint
         }
         // Tailscale is handled separately via exit node detection
         

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1270,7 +1270,7 @@ struct GeneralTab: View {
                 
                 Spacer()
                 
-                Link(destination: URL(string: "https://github.com/GeiserX/vpn-macos-bypass")!) {
+                Link(destination: URL(string: "https://github.com/GeiserX/VPN-Bypass")!) {
                     HStack(spacing: 6) {
                         Image(systemName: "star.fill")
                             .font(.system(size: 10))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to VPN Bypass will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Check Point VPN Detection** - Detects Check Point Endpoint Security VPN via process signatures (`Endpoint_Security_VPN`, `TracSrvWrapper`, `cpdaApp`, `cpefrd`)
+
+### Fixed
+- **Homebrew Tap Command** - Fixed `brew tap geiserx/tap` (repo doesn't exist) to `brew tap geiserx/vpn-bypass`
+- **Stale Repository URLs** - Updated all remaining `vpn-macos-bypass` references to `VPN-Bypass` across README, issue templates, cask, and settings
+
 ## [1.6.11] - 2026-02-05
 
 ### Improved


### PR DESCRIPTION
## Summary

- **Check Point VPN detection** (#4): Added process-based detection for Check Point Endpoint Security VPN (`Endpoint_Security_VPN`, `TracSrvWrapper`, `cpdaApp`, `cpefrd`). Enum case, icon, and README table updated.
- **Homebrew tap fix** (#5): `brew tap geiserx/tap` pointed to a non-existent repo. Fixed to `brew tap geiserx/vpn-bypass`.
- **Stale URL cleanup**: Replaced all remaining `vpn-macos-bypass` references with `VPN-Bypass` across README, issue templates, cask comment, and SettingsView.

Closes #4, Closes #5

## Test plan

- [ ] Verify `brew tap geiserx/vpn-bypass` works
- [ ] Verify Check Point detection with a live Check Point install (or mock `ps` output)
- [ ] Verify all GitHub links in README, issue templates, and settings resolve correctly