### PR TITLE
feat: auto-merge built-in service updates on config load

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -197,7 +197,7 @@ For teams and organizations:
 
 ## Technical Debt / Known Issues
 
-- [ ] Config migration: new default services don't auto-merge into existing user config
+- [x] Config migration: new default services don't auto-merge into existing user config
 - [ ] Helper installation can fail silently on some systems
 - [ ] Route verification unreliable (many servers block ICMP)
 - [ ] Homebrew Cask not published to a tap yet

--- a/Sources/RouteManager.swift
+++ b/Sources/RouteManager.swift
@@ -377,7 +377,58 @@ final class RouteManager: ObservableObject {
             return
         }
         config = loaded
+        mergeBuiltInServices()
         log(.info, "Config loaded")
+    }
+    
+    /// Merge built-in service definitions with the user's saved config.
+    /// Preserves the user's enabled/disabled state while updating domains,
+    /// ipRanges, and names from the latest source code definitions.
+    /// Also adds any new built-in services that didn't exist when the user last saved.
+    private func mergeBuiltInServices() {
+        let defaults = Config.defaultServices
+        let savedById = Dictionary(uniqueKeysWithValues: config.services.map { ($0.id, $0) })
+        let defaultById = Dictionary(uniqueKeysWithValues: defaults.map { ($0.id, $0) })
+        
+        var merged: [ServiceEntry] = []
+        var updated = 0
+        var added = 0
+        
+        // Walk the default list to preserve ordering from source code
+        for builtIn in defaults {
+            if let saved = savedById[builtIn.id] {
+                let domainsChanged = Set(saved.domains) != Set(builtIn.domains)
+                let ipRangesChanged = Set(saved.ipRanges) != Set(builtIn.ipRanges)
+                if domainsChanged || ipRangesChanged || saved.name != builtIn.name {
+                    updated += 1
+                }
+                merged.append(ServiceEntry(
+                    id: builtIn.id,
+                    name: builtIn.name,
+                    enabled: saved.enabled,
+                    domains: builtIn.domains,
+                    ipRanges: builtIn.ipRanges
+                ))
+            } else {
+                added += 1
+                merged.append(builtIn)
+            }
+        }
+        
+        // Keep any services from the saved config that aren't in defaults (future-proofing)
+        for saved in config.services where defaultById[saved.id] == nil {
+            merged.append(saved)
+        }
+        
+        if updated > 0 || added > 0 {
+            config.services = merged
+            saveConfig()
+            if updated > 0 { log(.info, "Updated \(updated) built-in service(s) with latest definitions") }
+            if added > 0 { log(.info, "Added \(added) new built-in service(s)") }
+        } else if config.services.count != merged.count {
+            config.services = merged
+            saveConfig()
+        }
     }
     
     func saveConfig() {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1263,7 +1263,7 @@ struct GeneralTab: View {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
                     BrandedAppName(fontSize: 13)
-                    Text("Version 1.8.1")
+                    Text("Version 1.9.0")
                         .font(.system(size: 11))
                         .foregroundColor(Color(hex: "6B7280"))
                 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to VPN Bypass will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.8.3] - 2026-02-28
+## [1.9.0] - 2026-02-28
+
+### Added
+- **Auto-Merge Built-In Service Updates** - App updates now automatically apply new domains, IP ranges, and service names from the latest version while preserving your enabled/disabled preferences. No more stale domain lists after upgrading
 
 ### Improved
 - **OpenAI / ChatGPT Service** - Added all relevant OpenAI and ChatGPT domains including core properties, auth, CDN, Azure/Cloudflare infrastructure, LiveKit voice, anti-bot, and analytics endpoints


### PR DESCRIPTION
## Summary

- On startup, `mergeBuiltInServices()` reconciles the user's saved config with the latest `defaultServices` definitions
- Domains, IP ranges, and service names are always taken from the source code
- User's enabled/disabled preferences are preserved
- New services added in future releases appear automatically
- Config is only re-saved when changes are detected (no unnecessary writes)

## How it works

1. After loading `config.json`, builds a lookup of saved services by `id`
2. Walks `defaultServices` in order (preserving source code ordering)
3. For each built-in service:
   - If it exists in saved config: takes `enabled` from saved, everything else from built-in
   - If it's new: adds it with defaults (`enabled: false`)
4. Appends any non-default services from saved config (forward compatibility)
5. Logs what changed and saves only if the merge produced differences

## Test plan

- [ ] Fresh install: no config.json exists, app uses defaults — no merge needed
- [ ] Existing install with old OpenAI domains: after upgrade, OpenAI service should have all ~30 new domains while preserving enabled/disabled state
- [ ] Enable some services, upgrade, verify they remain enabled with updated domains
- [ ] New service added to source code appears in existing user's service list
- [ ] Config.json is only rewritten when actual changes are detected
- [ ] Export/import still works correctly

Closes #13