### PR TITLE
fix: prefer route-output interface for VPN gateway detection

### DIFF
--- a/Sources/RouteManager.swift
+++ b/Sources/RouteManager.swift
@@ -3082,8 +3082,11 @@ final class RouteManager: ObservableObject {
         // Prefer IP gateway when available
         if let gw = gateway { return gw }
 
-        // No IP gateway — use interface from route output (authoritative for multi-VPN)
-        if let iface = routeInterface { return "iface:\(iface)" }
+        // No IP gateway — use interface from route output when it still looks
+        // like a VPN/tunnel device. This preserves the multi-VPN fix without
+        // turning an odd physical default interface into an invalid helper
+        // gateway like `iface:en0`.
+        if let iface = routeInterface, isVPNInterface(iface) { return "iface:\(iface)" }
 
         // Last resort: use detected VPN interface from ifconfig
         if let iface = vpnInterface { return "iface:\(iface)" }

--- a/Sources/RouteManager.swift
+++ b/Sources/RouteManager.swift
@@ -3051,16 +3051,43 @@ final class RouteManager: ObservableObject {
     }
 
     /// Detect VPN gateway for VPN Only mode routing.
+    /// Parses `route -n get default` for both gateway IP and interface.
     /// Falls back to interface-based routing when no IP gateway is available
     /// (e.g., Cisco Secure Client routes via link# without setting an IP gateway).
     private func detectVPNGateway() async -> String? {
-        if let ipGateway = await parseDefaultGateway() {
-            return ipGateway
+        guard let result = await runProcessAsync("/sbin/route", arguments: ["-n", "get", "default"], timeout: 3.0) else {
+            if let iface = vpnInterface { return "iface:\(iface)" }
+            return nil
         }
-        // No IP gateway — fall back to interface-based routing
-        if let iface = vpnInterface {
-            return "iface:\(iface)"
+
+        var gateway: String?
+        var routeInterface: String?
+
+        for line in result.output.components(separatedBy: "\n") {
+            if line.contains("gateway:") {
+                let parts = line.components(separatedBy: ":")
+                if parts.count >= 2 {
+                    let gw = parts[1].trimmingCharacters(in: .whitespaces)
+                    if isValidIP(gw) { gateway = gw }
+                }
+            }
+            if line.contains("interface:") {
+                let parts = line.components(separatedBy: ":")
+                if parts.count >= 2 {
+                    routeInterface = parts[1].trimmingCharacters(in: .whitespaces)
+                }
+            }
         }
+
+        // Prefer IP gateway when available
+        if let gw = gateway { return gw }
+
+        // No IP gateway — use interface from route output (authoritative for multi-VPN)
+        if let iface = routeInterface { return "iface:\(iface)" }
+
+        // Last resort: use detected VPN interface from ifconfig
+        if let iface = vpnInterface { return "iface:\(iface)" }
+
         return nil
     }
     


### PR DESCRIPTION
## Summary
- In multi-VPN setups, `detectVPNGateway()` used `vpnInterface` from ifconfig (first matching utun), which could pick the wrong tunnel
- Now parses the `interface:` line from `route -n get default` itself, which is authoritative for the kernel default route
- Three-tier fallback: IP gateway → route-output interface → ifconfig-detected interface

## Context
Review finding from #26 fix (v2.4.0). The Cisco Secure Client fix works correctly for single-VPN setups, but could bind routes to the wrong tunnel when multiple utun interfaces exist.

## Test plan
- [ ] Single VPN (Cisco Secure Client): VPN Only mode still works with interface-based routing
- [ ] Verify `route -n get default` interface line is parsed correctly
- [ ] Multi-VPN: routes go through the kernel default route interface, not first ifconfig match

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN gateway detection to more reliably identify gateway IPs and VPN/tunnel interfaces.
  * Better fallback logic and timeout handling when resolving network routes, reducing false positives in multi‑VPN setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->