### PR TITLE
fix: hide UI immediately on quit to prevent freeze

### DIFF
--- a/Sources/VPNBypassApp.swift
+++ b/Sources/VPNBypassApp.swift
@@ -100,7 +100,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         startWatchdog()
     }
     
-    func applicationWillTerminate(_ notification: Notification) {
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         // Hide all UI immediately so quit feels instant
         NSApp.windows.forEach { $0.orderOut(nil) }
 
@@ -110,15 +110,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         networkDebounceWorkItem?.cancel()
         RouteManager.shared.stopDNSRefreshTimer()
 
-        // Clean up routes and hosts file on quit
-        // Always run: removes VPN Only catch-all routes and /etc/hosts entries
-        let semaphore = DispatchSemaphore(value: 0)
-        Task {
+        // Clean up routes and hosts file on quit, then allow termination
+        Task { @MainActor in
             await RouteManager.shared.cleanupOnQuit()
-            semaphore.signal()
+            NSApp.reply(toApplicationShouldTerminate: true)
         }
-        // Block termination until cleanup completes (up to 5s)
-        _ = semaphore.wait(timeout: .now() + 5)
+        return .terminateLater
     }
     
     // MARK: - Network Monitoring

--- a/Sources/VPNBypassApp.swift
+++ b/Sources/VPNBypassApp.swift
@@ -101,12 +101,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func applicationWillTerminate(_ notification: Notification) {
+        // Hide all UI immediately so quit feels instant
+        NSApp.windows.forEach { $0.orderOut(nil) }
+
         networkMonitor?.cancel()
         refreshTimer?.invalidate()
         watchdogTimer?.invalidate()
         networkDebounceWorkItem?.cancel()
         RouteManager.shared.stopDNSRefreshTimer()
-        
+
         // Clean up routes and hosts file on quit
         // Always run: removes VPN Only catch-all routes and /etc/hosts entries
         let semaphore = DispatchSemaphore(value: 0)


### PR DESCRIPTION
## Summary
- Hides all windows (popover, settings) immediately at the start of `applicationWillTerminate` so the app visually disappears before route cleanup runs
- Previously, the 5-second semaphore wait for async cleanup blocked the main thread, causing the UI to freeze before disappearing

## Test plan
- [ ] Open the menu bar popover and click the quit button
- [ ] Verify the popover disappears instantly (no freeze)
- [ ] Verify routes are still cleaned up properly after quit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * App now immediately hides all windows when quitting for a cleaner, more responsive shutdown.
  * Shutdown sequence no longer blocks UI; network monitoring and timers are stopped without freezing the app.
  * Route/hosts cleanup runs asynchronously and completion defers final termination until cleanup finishes, ensuring a safe and reliable exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->