### PR TITLE
fix: address review findings from security and architecture audit

### DIFF
--- a/Helper/HelperTool.swift
+++ b/Helper/HelperTool.swift
@@ -205,12 +205,16 @@ class HelperTool: NSObject, HelperProtocol {
         }
         
         // Collect domains already managed by other tools (outside our block)
-        let externalDomains: Set<String> = Set(lines.compactMap { line in
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { return nil }
-            let parts = trimmed.split(separator: " ", maxSplits: 1)
-            guard parts.count == 2 else { return nil }
-            return String(parts[1]).trimmingCharacters(in: .whitespaces).lowercased()
+        let externalDomains: Set<String> = Set(lines.flatMap { line -> [String] in
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { return [] }
+            var fields = trimmed.split(whereSeparator: { $0.isWhitespace })
+            guard fields.count >= 2 else { return [] }
+            fields.removeFirst() // drop IP
+            if let commentIdx = fields.firstIndex(where: { $0.hasPrefix("#") }) {
+                fields = Array(fields[..<commentIdx])
+            }
+            return fields.map { String($0).lowercased() }
         })
 
         // Add new section if we have entries (skip domains managed by other tools)

--- a/Sources/RouteManager.swift
+++ b/Sources/RouteManager.swift
@@ -2232,7 +2232,18 @@ final class RouteManager: ObservableObject {
         // Test TCP connection to proxy server
         let server = config.proxyConfig.server
         let port = config.proxyConfig.port
-        
+
+        // Validate server is a valid hostname/IP (reject flag injection)
+        guard !server.isEmpty,
+              !server.hasPrefix("-"),
+              server.range(of: #"^[a-zA-Z0-9]([a-zA-Z0-9.\-]*[a-zA-Z0-9])?$"#, options: .regularExpression) != nil,
+              port > 0, port < 65536 else {
+            await MainActor.run {
+                proxyTestResult = ProxyTestResult(success: false, message: "Invalid server or port")
+            }
+            return
+        }
+
         // Use nc (netcat) to test connection
         let args = ["-z", "-w", "5", server, String(port)]
         guard let result = await runProcessAsync("/usr/bin/nc", arguments: args, timeout: 6.0) else {
@@ -3254,6 +3265,9 @@ final class RouteManager: ObservableObject {
     }
     
     private nonisolated static func resolveWithDNSParallel(_ domain: String, dns: String) async -> [String]? {
+        // Reject domains that could be interpreted as flags
+        guard !domain.isEmpty, !domain.hasPrefix("-") else { return nil }
+
         // Check protocol type
         if dns.hasPrefix("https://") {
             // DoH (DNS over HTTPS)

--- a/Sources/VPNBypassApp.swift
+++ b/Sources/VPNBypassApp.swift
@@ -111,8 +111,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         RouteManager.shared.stopDNSRefreshTimer()
 
         // Clean up routes and hosts file on quit, then allow termination
+        var didReply = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 8) {
+            guard !didReply else { return }
+            didReply = true
+            NSApp.reply(toApplicationShouldTerminate: true)
+        }
         Task { @MainActor in
             await RouteManager.shared.cleanupOnQuit()
+            guard !didReply else { return }
+            didReply = true
             NSApp.reply(toApplicationShouldTerminate: true)
         }
         return .terminateLater


### PR DESCRIPTION
## Summary
Fixes from a multi-agent review (code, security, architecture, test coverage):

- **Hosts collision detection**: now handles tab-separated entries, multi-hostname lines, and inline comments — previously only split on spaces, missing standard `/etc/hosts` format
- **Quit timeout safety net**: 8-second hard deadline ensures termination even if cleanup Task stalls beyond XPC timeouts
- **Proxy server validation**: rejects flag injection (e.g. `-e /bin/sh`) before passing to `/usr/bin/nc`
- **DNS domain validation**: rejects domains starting with `-` before passing to `dig`/`kdig`/`curl`

## Not addressed (separate work)
- XPC code-signing anchor check (needs Developer ID cert info)
- Proxy password to Keychain (significant refactor)
- Log file from `/tmp` to `~/Library/Application Support`

## Test plan
- [ ] Verify VPN Bypass skips hosts entries managed by other tools (tab-separated, multi-hostname)
- [ ] Quit the app and verify it exits cleanly within seconds
- [ ] Enter invalid proxy server values and verify they are rejected
- [ ] Verify normal DNS resolution still works for configured domains