### PR TITLE
feat: add CIDR/subnet support in VPN Only mode

### DIFF
--- a/Helper/HelperTool.swift
+++ b/Helper/HelperTool.swift
@@ -311,9 +311,10 @@ class HelperTool: NSObject, HelperProtocol {
     private func isValidIP(_ string: String) -> Bool {
         let parts = string.components(separatedBy: ".")
         guard parts.count == 4 else { return false }
-        return parts.allSatisfy { 
-            guard let num = Int($0) else { return false }
-            return num >= 0 && num <= 255
+        return parts.allSatisfy {
+            guard let num = Int($0), num >= 0, num <= 255 else { return false }
+            // Reject leading zeros (e.g., "010") — route interprets them as octal
+            return String(num) == $0
         }
     }
     

--- a/Helper/Info.plist
+++ b/Helper/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleName</key>
     <string>VPNBypassHelper</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.1.0</string>
+    <string>1.5.0</string>
     <key>CFBundleVersion</key>
-    <string>2</string>
+    <string>5</string>
     <key>SMAuthorizedClients</key>
     <array>
         <!-- The main app that can communicate with this helper -->

--- a/Sources/HelperProtocol.swift
+++ b/Sources/HelperProtocol.swift
@@ -78,7 +78,7 @@ protocol HelperProgressProtocol {
 // MARK: - Helper Constants
 
 struct HelperConstants {
-    static let helperVersion = "1.4.0"
+    static let helperVersion = "1.5.0"
     static let bundleID = "com.geiserx.vpnbypass.helper"
     static let hostMarkerStart = "# VPN-BYPASS-MANAGED - START"
     static let hostMarkerEnd = "# VPN-BYPASS-MANAGED - END"

--- a/Sources/MenuBarViews.swift
+++ b/Sources/MenuBarViews.swift
@@ -445,7 +445,7 @@ struct MenuContent: View {
             if routeManager.config.routingMode == .vpnOnly {
                 let enabledDomains = routeManager.config.inverseDomains.filter { $0.enabled }
                 HStack(spacing: 16) {
-                    StatBadge(value: "\(enabledDomains.count)", label: "VPN Domains")
+                    StatBadge(value: "\(enabledDomains.count)", label: "VPN Entries")
                 }
             } else {
                 let enabledServices = routeManager.config.services.filter { $0.enabled }

--- a/Sources/RouteManager.swift
+++ b/Sources/RouteManager.swift
@@ -329,11 +329,23 @@ final class RouteManager: ObservableObject {
         var enabled: Bool
         var resolvedIP: String?
         var lastResolved: Date?
-        
-        init(domain: String, enabled: Bool = true) {
+        var isCIDR: Bool
+
+        init(domain: String, enabled: Bool = true, isCIDR: Bool = false) {
             self.id = UUID()
             self.domain = domain
             self.enabled = enabled
+            self.isCIDR = isCIDR
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            domain = try container.decode(String.self, forKey: .domain)
+            enabled = try container.decode(Bool.self, forKey: .enabled)
+            resolvedIP = try container.decodeIfPresent(String.self, forKey: .resolvedIP)
+            lastResolved = try container.decodeIfPresent(Date.self, forKey: .lastResolved)
+            isCIDR = try container.decodeIfPresent(Bool.self, forKey: .isCIDR) ?? false
         }
     }
     
@@ -1213,10 +1225,18 @@ final class RouteManager: ObservableObject {
         // Collect all domains to resolve (for parallel resolution)
         var allDomains: [(domain: String, source: String)] = []
 
+        // Collect CIDR entries separately (added to route structures after variable declarations)
+        var inverseCIDRs: [String] = []
+
         if isInverse {
             // VPN Only mode: resolve inverse domains (these go through VPN)
+            // CIDR entries are routed directly as network routes, not DNS-resolved
             for domain in config.inverseDomains where domain.enabled {
-                allDomains.append((domain.domain, domain.domain))
+                if domain.isCIDR {
+                    inverseCIDRs.append(domain.domain)
+                } else {
+                    allDomains.append((domain.domain, domain.domain))
+                }
             }
         } else {
             // Bypass mode: resolve bypass domains + service domains
@@ -1260,8 +1280,21 @@ final class RouteManager: ObservableObject {
             allSourceEntries.append((destination: "128.0.0.0/1", source: "VPN Only catch-all"))
             seenSourceDests.insert("VPN Only catch-all|0.0.0.0/1")
             seenSourceDests.insert("VPN Only catch-all|128.0.0.0/1")
+
+            // Add CIDR entries as network routes through VPN gateway
+            for cidr in inverseCIDRs {
+                if !seenDestinations.contains(cidr) {
+                    seenDestinations.insert(cidr)
+                    routesToAdd.append((destination: cidr, gateway: routeGateway, isNetwork: true, source: cidr))
+                }
+                let key = "\(cidr)|\(cidr)"
+                if !seenSourceDests.contains(key) {
+                    seenSourceDests.insert(key)
+                    allSourceEntries.append((destination: cidr, source: cidr))
+                }
+            }
         }
-        
+
         while index < allDomains.count {
             let endIndex = min(index + batchSize, allDomains.count)
             let batch = Array(allDomains[index..<endIndex])
@@ -1550,7 +1583,19 @@ final class RouteManager: ObservableObject {
             seenSourceDests.insert("VPN Only catch-all|128.0.0.0/1")
 
             for domain in config.inverseDomains where domain.enabled {
-                if let cachedIPs = dnsDiskCache[domain.domain] {
+                if domain.isCIDR {
+                    // CIDR entries: route directly as network routes, no DNS cache
+                    let cidr = domain.domain
+                    let key = "\(cidr)|\(cidr)"
+                    if !seenSourceDests.contains(key) {
+                        seenSourceDests.insert(key)
+                        allSourceEntries.append((destination: cidr, gateway: routeGateway, source: cidr))
+                    }
+                    if !seenDestinations.contains(cidr) {
+                        seenDestinations.insert(cidr)
+                        routesToAdd.append((destination: cidr, gateway: routeGateway, isNetwork: true, source: cidr))
+                    }
+                } else if let cachedIPs = dnsDiskCache[domain.domain] {
                     for ip in cachedIPs {
                         let key = "\(domain.domain)|\(ip)"
                         if !seenSourceDests.contains(key) {
@@ -1731,7 +1776,9 @@ final class RouteManager: ObservableObject {
         var domainsToResolve: [(domain: String, source: String)] = []
         if isInverse {
             for domain in config.inverseDomains where domain.enabled {
-                domainsToResolve.append((domain.domain, domain.domain))
+                if !domain.isCIDR {
+                    domainsToResolve.append((domain.domain, domain.domain))
+                }
             }
         } else {
             for service in config.services where service.enabled {
@@ -2036,7 +2083,12 @@ final class RouteManager: ObservableObject {
 
         if isInverse {
             for domain in config.inverseDomains where domain.enabled {
-                domainsToResolve.append((domain.domain, domain.domain))
+                if domain.isCIDR {
+                    // CIDR entries: preserve as static routes, no DNS resolution
+                    expectedEntries.insert(SourceDest(source: domain.domain, destination: domain.domain))
+                } else {
+                    domainsToResolve.append((domain.domain, domain.domain))
+                }
             }
         } else {
             for domain in config.domains where domain.enabled {
@@ -2135,6 +2187,27 @@ final class RouteManager: ObservableObject {
                         updatedCount += 1
                         log(.success, "DNS refresh: repaired missing CIDR route \(range) for \(service.name)")
                     }
+                }
+            }
+        }
+
+        // VPN Only CIDR entries: repair missing network routes
+        if isInverse {
+            for domain in config.inverseDomains where domain.enabled && domain.isCIDR {
+                let cidr = domain.domain
+                // Already tracked in expectedEntries above
+                if existingDestinations.contains(cidr) { continue }
+                if addedKernelRoutes.contains(cidr) { continue }
+                if await addRoute(cidr, gateway: routeGateway, isNetwork: true) {
+                    activeRoutes.append(ActiveRoute(
+                        destination: cidr,
+                        gateway: routeGateway,
+                        source: cidr,
+                        timestamp: Date()
+                    ))
+                    addedKernelRoutes.insert(cidr)
+                    updatedCount += 1
+                    log(.success, "DNS refresh: repaired missing CIDR route \(cidr)")
                 }
             }
         }
@@ -2491,25 +2564,47 @@ final class RouteManager: ObservableObject {
     // MARK: - Inverse Domain Management
 
     func addInverseDomain(_ domain: String) {
-        let cleaned = cleanDomain(domain)
-        guard !cleaned.isEmpty else { return }
-        guard !config.inverseDomains.contains(where: { $0.domain == cleaned }) else {
-            log(.warning, "VPN Only domain \(cleaned) already exists")
+        let trimmed = domain.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Detect CIDR input (e.g., "192.168.1.0/24") — bypass domain cleaning
+        let cidr = isValidCIDR(trimmed)
+        let entry: String
+        if cidr {
+            entry = trimmed
+        } else {
+            entry = cleanDomain(trimmed)
+            guard !entry.isEmpty else { return }
+        }
+
+        guard !config.inverseDomains.contains(where: { $0.domain == entry }) else {
+            log(.warning, "VPN Only entry \(entry) already exists")
             return
         }
-        config.inverseDomains.append(DomainEntry(domain: cleaned))
+        config.inverseDomains.append(DomainEntry(domain: entry, isCIDR: cidr))
         saveConfig()
-        log(.success, "Added VPN Only domain: \(cleaned)")
+        log(.success, "Added VPN Only \(cidr ? "CIDR" : "domain"): \(entry)")
 
         if isVPNConnected && config.routingMode == .vpnOnly && acquireRouteOperation() {
             Task {
                 defer { releaseRouteOperation() }
                 let epoch = routeEpoch
                 guard let gw = vpnGateway else {
-                    log(.error, "Cannot route \(cleaned): no VPN gateway detected")
+                    log(.error, "Cannot route \(entry): no VPN gateway detected")
                     return
                 }
-                if let routes = await applyRoutesForDomain(cleaned, gateway: gw) {
+                if cidr {
+                    // CIDR: add network route directly, no DNS resolution needed
+                    if await addRoute(entry, gateway: gw, isNetwork: true) {
+                        guard routeEpoch == epoch else { return }
+                        activeRoutes.append(ActiveRoute(
+                            destination: entry,
+                            gateway: gw,
+                            source: entry,
+                            timestamp: Date()
+                        ))
+                        log(.success, "Routed CIDR \(entry) through VPN")
+                    }
+                } else if let routes = await applyRoutesForDomain(entry, gateway: gw) {
                     guard routeEpoch == epoch else { return }
                     activeRoutes.append(contentsOf: routes)
                     if config.manageHostsFile { await updateHostsFile() }
@@ -2522,7 +2617,7 @@ final class RouteManager: ObservableObject {
         guard acquireRouteOperation() else {
             config.inverseDomains.removeAll { $0.id == domain.id }
             saveConfig()
-            log(.info, "Removed VPN Only domain: \(domain.domain) (route cleanup deferred)")
+            log(.info, "Removed VPN Only \(domain.isCIDR ? "CIDR" : "domain"): \(domain.domain) (route cleanup deferred)")
             return
         }
         Task {
@@ -2531,7 +2626,7 @@ final class RouteManager: ObservableObject {
             config.inverseDomains.removeAll { $0.id == domain.id }
             saveConfig()
             if config.manageHostsFile { await updateHostsFile() }
-            log(.info, "Removed VPN Only domain: \(domain.domain)")
+            log(.info, "Removed VPN Only \(domain.isCIDR ? "CIDR" : "domain"): \(domain.domain)")
         }
     }
 
@@ -2549,7 +2644,18 @@ final class RouteManager: ObservableObject {
                 let epoch = routeEpoch
                 if domain.enabled {
                     guard let gw = vpnGateway else { return }
-                    if let routes = await applyRoutesForDomain(domain.domain, gateway: gw) {
+                    if domain.isCIDR {
+                        // CIDR: add network route directly
+                        if await addRoute(domain.domain, gateway: gw, isNetwork: true) {
+                            guard routeEpoch == epoch else { return }
+                            activeRoutes.append(ActiveRoute(
+                                destination: domain.domain,
+                                gateway: gw,
+                                source: domain.domain,
+                                timestamp: Date()
+                            ))
+                        }
+                    } else if let routes = await applyRoutesForDomain(domain.domain, gateway: gw) {
                         guard routeEpoch == epoch else { return }
                         activeRoutes.append(contentsOf: routes)
                         if config.manageHostsFile { await updateHostsFile() }
@@ -3364,7 +3470,10 @@ final class RouteManager: ObservableObject {
     private nonisolated static func isValidIPStatic(_ string: String) -> Bool {
         let parts = string.components(separatedBy: ".")
         guard parts.count == 4 else { return false }
-        return parts.allSatisfy { Int($0) != nil && Int($0)! >= 0 && Int($0)! <= 255 }
+        return parts.allSatisfy {
+            guard let num = Int($0), num >= 0, num <= 255 else { return false }
+            return String(num) == $0
+        }
     }
     
     private func addRoute(_ destination: String, gateway: String, isNetwork: Bool = false) async -> Bool {
@@ -3398,6 +3507,8 @@ final class RouteManager: ObservableObject {
         let activeDomains: [DomainEntry] = config.routingMode == .vpnOnly ? config.inverseDomains : config.domains
 
         for domain in activeDomains {
+            // CIDR entries don't have domain names to map in hosts file
+            guard !domain.isCIDR else { continue }
             // Include enabled domains AND disabled domains that still have active kernel routes
             guard domain.enabled || activeRoutes.contains(where: { $0.source == domain.domain }) else { continue }
             if let ip = firstRoutedIP(for: domain.domain, in: routedDestinations) {
@@ -3546,7 +3657,24 @@ final class RouteManager: ObservableObject {
     private func isValidIP(_ string: String) -> Bool {
         let parts = string.components(separatedBy: ".")
         guard parts.count == 4 else { return false }
-        return parts.allSatisfy { Int($0) != nil && Int($0)! >= 0 && Int($0)! <= 255 }
+        return parts.allSatisfy {
+            guard let num = Int($0), num >= 0, num <= 255 else { return false }
+            // Reject leading zeros (e.g., "010") — route interprets them as octal
+            return String(num) == $0
+        }
+    }
+
+    /// Validate CIDR notation (e.g., "192.168.1.0/24")
+    /// Rejects /0 which would conflict with VPN Only catch-all routes.
+    private func isValidCIDR(_ string: String) -> Bool {
+        let parts = string.components(separatedBy: "/")
+        guard parts.count == 2,
+              isValidIP(parts[0]),
+              let mask = Int(parts[1]),
+              mask >= 1 && mask <= 32 else {
+            return false
+        }
+        return true
     }
     
     func log(_ level: LogEntry.LogLevel, _ message: String) {

--- a/Sources/RouteManager.swift
+++ b/Sources/RouteManager.swift
@@ -2571,6 +2571,9 @@ final class RouteManager: ObservableObject {
         let entry: String
         if cidr {
             entry = trimmed
+        } else if trimmed.contains("/") {
+            log(.warning, "Invalid CIDR notation: \(trimmed)")
+            return
         } else {
             entry = cleanDomain(trimmed)
             guard !entry.isEmpty else { return }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -210,7 +210,7 @@ struct DomainsTab: View {
                         .font(.system(size: 12))
                         .foregroundColor(Color(hex: "6B7280"))
                     
-                    TextField("Enter domain (e.g., example.com)", text: $newDomain)
+                    TextField(isInverse ? "e.g., example.com or 10.0.0.0/24" : "Enter domain (e.g., example.com)", text: $newDomain)
                         .textFieldStyle(.plain)
                         .font(.system(size: 13))
                         .focused($isInputFocused)
@@ -347,10 +347,10 @@ struct DomainsTab: View {
             Image(systemName: isInverse ? "lock.shield" : "globe")
                 .font(.system(size: 28))
                 .foregroundColor(Color(hex: "374151"))
-            Text("No domains configured")
+            Text("No entries configured")
                 .font(.system(size: 13))
                 .foregroundColor(Color(hex: "6B7280"))
-            Text(isInverse ? "Add domains that should use VPN" : "Add a domain above to bypass VPN")
+            Text(isInverse ? "Add domains or IP ranges that should use VPN" : "Add a domain above to bypass VPN")
                 .font(.system(size: 11))
                 .foregroundColor(Color(hex: "4B5563"))
         }
@@ -384,9 +384,20 @@ struct DomainRow: View {
                 .shadow(color: domain.enabled ? Color(hex: "10B981").opacity(0.5) : .clear, radius: 4)
             
             VStack(alignment: .leading, spacing: 2) {
-                Text(domain.domain)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(domain.enabled ? .white : Color(hex: "9CA3AF"))
+                HStack(spacing: 6) {
+                    Text(domain.domain)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(domain.enabled ? .white : Color(hex: "9CA3AF"))
+                    if domain.isCIDR {
+                        Text("CIDR")
+                            .font(.system(size: 9, weight: .bold))
+                            .foregroundColor(Color(hex: "F59E0B"))
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(Color(hex: "F59E0B").opacity(0.15))
+                            .cornerRadius(4)
+                    }
+                }
             }
             
             Spacer()

--- a/Tests/VPNBypassTests/VPNBypassTests.swift
+++ b/Tests/VPNBypassTests/VPNBypassTests.swift
@@ -686,7 +686,7 @@ final class HelperConstantsTests: XCTestCase {
 
     func testHelperVersionFormat() {
         // Version must be semver-like: X.Y.Z
-        let version = "1.4.0"
+        let version = "1.5.0"
         let parts = version.components(separatedBy: ".")
         XCTAssertEqual(parts.count, 3)
         XCTAssertNotNil(Int(parts[0]))

--- a/Tests/VPNBypassTests/VPNBypassTests.swift
+++ b/Tests/VPNBypassTests/VPNBypassTests.swift
@@ -13,8 +13,8 @@ final class IPValidationTests: XCTestCase {
         let parts = string.components(separatedBy: ".")
         guard parts.count == 4 else { return false }
         return parts.allSatisfy {
-            guard let num = Int($0) else { return false }
-            return num >= 0 && num <= 255
+            guard let num = Int($0), num >= 0, num <= 255 else { return false }
+            return String(num) == $0
         }
     }
 
@@ -179,6 +179,443 @@ final class IPValidationTests: XCTestCase {
             args.append(gateway)
         }
         return args
+    }
+}
+
+// MARK: - CIDR Validation Tests
+
+/// Tests for the isValidCIDR() function that validates CIDR notation inputs.
+final class CIDRValidationTests: XCTestCase {
+
+    // Reimplementation of RouteManager.isValidIP (same as IPValidationTests)
+    private func isValidIP(_ string: String) -> Bool {
+        let parts = string.components(separatedBy: ".")
+        guard parts.count == 4 else { return false }
+        return parts.allSatisfy {
+            guard let num = Int($0), num >= 0, num <= 255 else { return false }
+            return String(num) == $0
+        }
+    }
+
+    // Reimplementation of RouteManager.isValidCIDR
+    // Rejects /0 which would conflict with VPN Only catch-all routes.
+    private func isValidCIDR(_ string: String) -> Bool {
+        let parts = string.components(separatedBy: "/")
+        guard parts.count == 2,
+              isValidIP(parts[0]),
+              let mask = Int(parts[1]),
+              mask >= 1 && mask <= 32 else {
+            return false
+        }
+        return true
+    }
+
+    // MARK: - Valid CIDRs
+
+    func testValidCIDRWithCommonSubnets() {
+        XCTAssertTrue(isValidCIDR("10.0.0.0/8"))
+        XCTAssertTrue(isValidCIDR("172.16.0.0/12"))
+        XCTAssertTrue(isValidCIDR("192.168.1.0/24"))
+        XCTAssertTrue(isValidCIDR("192.168.0.0/16"))
+    }
+
+    func testValidCIDRWithHostMask() {
+        // /32 = single host
+        XCTAssertTrue(isValidCIDR("1.2.3.4/32"))
+        XCTAssertTrue(isValidCIDR("255.255.255.255/32"))
+    }
+
+    func testInvalidCIDRDefaultRoute() {
+        // /0 is rejected — would conflict with VPN Only catch-all routes
+        XCTAssertFalse(isValidCIDR("0.0.0.0/0"))
+        XCTAssertFalse(isValidCIDR("10.0.0.0/0"))
+    }
+
+    func testValidCIDRBoundaryMasks() {
+        XCTAssertTrue(isValidCIDR("10.0.0.0/1"))
+        XCTAssertTrue(isValidCIDR("10.0.0.0/31"))
+        XCTAssertTrue(isValidCIDR("10.0.0.0/32"))
+    }
+
+    // MARK: - Invalid CIDRs
+
+    func testInvalidCIDRMaskTooLarge() {
+        XCTAssertFalse(isValidCIDR("10.0.0.0/33"))
+        XCTAssertFalse(isValidCIDR("10.0.0.0/64"))
+        XCTAssertFalse(isValidCIDR("10.0.0.0/128"))
+    }
+
+    func testInvalidCIDRNegativeMask() {
+        XCTAssertFalse(isValidCIDR("10.0.0.0/-1"))
+        XCTAssertFalse(isValidCIDR("10.0.0.0/-32"))
+    }
+
+    func testInvalidCIDRNonNumericMask() {
+        XCTAssertFalse(isValidCIDR("10.0.0.0/abc"))
+        XCTAssertFalse(isValidCIDR("10.0.0.0/"))
+        XCTAssertFalse(isValidCIDR("10.0.0.0/xx"))
+    }
+
+    func testInvalidCIDRBadIPPart() {
+        XCTAssertFalse(isValidCIDR("999.0.0.0/24"))
+        XCTAssertFalse(isValidCIDR("not.an.ip.addr/24"))
+        XCTAssertFalse(isValidCIDR("1.2.3/24"))
+        XCTAssertFalse(isValidCIDR("256.1.1.1/24"))
+    }
+
+    func testInvalidCIDRMultipleSlashes() {
+        XCTAssertFalse(isValidCIDR("10.0.0.0/8/16"))
+        XCTAssertFalse(isValidCIDR("10.0.0.0//8"))
+    }
+
+    func testInvalidCIDREmptyString() {
+        XCTAssertFalse(isValidCIDR(""))
+    }
+
+    func testInvalidCIDRPlainIP() {
+        // Plain IP without mask is NOT a valid CIDR
+        XCTAssertFalse(isValidCIDR("192.168.1.1"))
+        XCTAssertFalse(isValidCIDR("10.0.0.1"))
+    }
+
+    func testInvalidCIDRDomainInput() {
+        // Domain names should never pass CIDR validation
+        XCTAssertFalse(isValidCIDR("example.com"))
+        XCTAssertFalse(isValidCIDR("example.com/24"))
+        XCTAssertFalse(isValidCIDR("sub.domain.org/16"))
+    }
+
+    func testInvalidCIDRWithWhitespace() {
+        // isValidCIDR does NOT trim — caller (addInverseDomain) trims first
+        XCTAssertFalse(isValidCIDR(" 10.0.0.0/8"))
+        XCTAssertFalse(isValidCIDR("10.0.0.0/8 "))
+        XCTAssertFalse(isValidCIDR(" 10.0.0.0/8 "))
+    }
+
+    func testInvalidCIDRWithProtocol() {
+        XCTAssertFalse(isValidCIDR("http://10.0.0.0/8"))
+    }
+}
+
+// MARK: - DomainEntry Codable Tests
+
+/// Tests for DomainEntry encoding/decoding, especially backward compatibility with isCIDR field.
+final class DomainEntryCodableTests: XCTestCase {
+
+    // Minimal reimplementation of DomainEntry for Codable testing
+    struct DomainEntry: Codable, Identifiable, Equatable {
+        let id: UUID
+        var domain: String
+        var enabled: Bool
+        var resolvedIP: String?
+        var lastResolved: Date?
+        var isCIDR: Bool
+
+        init(domain: String, enabled: Bool = true, isCIDR: Bool = false) {
+            self.id = UUID()
+            self.domain = domain
+            self.enabled = enabled
+            self.isCIDR = isCIDR
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            domain = try container.decode(String.self, forKey: .domain)
+            enabled = try container.decode(Bool.self, forKey: .enabled)
+            resolvedIP = try container.decodeIfPresent(String.self, forKey: .resolvedIP)
+            lastResolved = try container.decodeIfPresent(Date.self, forKey: .lastResolved)
+            isCIDR = try container.decodeIfPresent(Bool.self, forKey: .isCIDR) ?? false
+        }
+    }
+
+    // MARK: - Encoding
+
+    func testEncodeDomainEntryWithCIDRTrue() throws {
+        let entry = DomainEntry(domain: "10.0.0.0/8", isCIDR: true)
+        let data = try JSONEncoder().encode(entry)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(json["domain"] as? String, "10.0.0.0/8")
+        XCTAssertEqual(json["isCIDR"] as? Bool, true)
+        XCTAssertEqual(json["enabled"] as? Bool, true)
+    }
+
+    func testEncodeDomainEntryWithCIDRFalse() throws {
+        let entry = DomainEntry(domain: "example.com", isCIDR: false)
+        let data = try JSONEncoder().encode(entry)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(json["domain"] as? String, "example.com")
+        XCTAssertEqual(json["isCIDR"] as? Bool, false)
+    }
+
+    // MARK: - Decoding (backward compatibility)
+
+    func testDecodeOldJSONWithoutCIDRFieldDefaultsToFalse() throws {
+        // Simulates JSON saved before the isCIDR field was added
+        let id = UUID()
+        let json: [String: Any] = [
+            "id": id.uuidString,
+            "domain": "telegram.org",
+            "enabled": true
+        ]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let entry = try JSONDecoder().decode(DomainEntry.self, from: data)
+        XCTAssertEqual(entry.domain, "telegram.org")
+        XCTAssertEqual(entry.enabled, true)
+        XCTAssertEqual(entry.isCIDR, false)
+        XCTAssertNil(entry.resolvedIP)
+        XCTAssertNil(entry.lastResolved)
+    }
+
+    func testDecodeJSONWithCIDRTrue() throws {
+        let id = UUID()
+        let json: [String: Any] = [
+            "id": id.uuidString,
+            "domain": "192.168.1.0/24",
+            "enabled": true,
+            "isCIDR": true
+        ]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let entry = try JSONDecoder().decode(DomainEntry.self, from: data)
+        XCTAssertEqual(entry.domain, "192.168.1.0/24")
+        XCTAssertEqual(entry.isCIDR, true)
+    }
+
+    func testDecodeJSONWithCIDRExplicitlyFalse() throws {
+        let id = UUID()
+        let json: [String: Any] = [
+            "id": id.uuidString,
+            "domain": "example.com",
+            "enabled": true,
+            "isCIDR": false
+        ]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let entry = try JSONDecoder().decode(DomainEntry.self, from: data)
+        XCTAssertEqual(entry.domain, "example.com")
+        XCTAssertEqual(entry.isCIDR, false)
+    }
+
+    func testDecodeOldJSONWithResolvedIPPreserved() throws {
+        let id = UUID()
+        let json: [String: Any] = [
+            "id": id.uuidString,
+            "domain": "netflix.com",
+            "enabled": false,
+            "resolvedIP": "52.94.237.1"
+        ]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let entry = try JSONDecoder().decode(DomainEntry.self, from: data)
+        XCTAssertEqual(entry.domain, "netflix.com")
+        XCTAssertEqual(entry.enabled, false)
+        XCTAssertEqual(entry.resolvedIP, "52.94.237.1")
+        XCTAssertEqual(entry.isCIDR, false)
+    }
+
+    // MARK: - Round-trip
+
+    func testRoundTripCIDREntry() throws {
+        let original = DomainEntry(domain: "172.16.0.0/12", isCIDR: true)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(DomainEntry.self, from: data)
+        XCTAssertEqual(decoded.domain, original.domain)
+        XCTAssertEqual(decoded.enabled, original.enabled)
+        XCTAssertEqual(decoded.isCIDR, original.isCIDR)
+        XCTAssertEqual(decoded.id, original.id)
+    }
+
+    func testRoundTripDomainEntry() throws {
+        let original = DomainEntry(domain: "example.com", isCIDR: false)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(DomainEntry.self, from: data)
+        XCTAssertEqual(decoded.domain, original.domain)
+        XCTAssertEqual(decoded.isCIDR, false)
+    }
+
+    // MARK: - Init defaults
+
+    func testDomainEntryInitDefaultsCIDRToFalse() {
+        let entry = DomainEntry(domain: "google.com")
+        XCTAssertEqual(entry.isCIDR, false)
+        XCTAssertEqual(entry.enabled, true)
+    }
+
+    func testDomainEntryInitExplicitCIDR() {
+        let entry = DomainEntry(domain: "10.0.0.0/8", isCIDR: true)
+        XCTAssertEqual(entry.isCIDR, true)
+        XCTAssertEqual(entry.domain, "10.0.0.0/8")
+    }
+}
+
+// MARK: - AddInverseDomain Logic Tests
+
+/// Tests for the addInverseDomain detection logic: CIDR vs domain classification and deduplication.
+final class AddInverseDomainLogicTests: XCTestCase {
+
+    // Reimplementation of isValidIP
+    private func isValidIP(_ string: String) -> Bool {
+        let parts = string.components(separatedBy: ".")
+        guard parts.count == 4 else { return false }
+        return parts.allSatisfy {
+            guard let num = Int($0), num >= 0, num <= 255 else { return false }
+            return String(num) == $0
+        }
+    }
+
+    // Reimplementation of isValidCIDR
+    private func isValidCIDR(_ string: String) -> Bool {
+        let parts = string.components(separatedBy: "/")
+        guard parts.count == 2,
+              isValidIP(parts[0]),
+              let mask = Int(parts[1]),
+              mask >= 0 && mask <= 32 else {
+            return false
+        }
+        return true
+    }
+
+    // Simplified cleanDomain (mirrors RouteManager.cleanDomain core logic)
+    private func cleanDomain(_ input: String) -> String {
+        var domain = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Remove protocol scheme
+        if let schemeRange = domain.range(of: "^[a-zA-Z][a-zA-Z0-9+.-]*://", options: .regularExpression) {
+            domain = String(domain[schemeRange.upperBound...])
+        }
+        // Remove path/query/fragment
+        if let slashIndex = domain.firstIndex(of: "/") {
+            domain = String(domain[..<slashIndex])
+        }
+        if let queryIndex = domain.firstIndex(of: "?") {
+            domain = String(domain[..<queryIndex])
+        }
+        if let fragmentIndex = domain.firstIndex(of: "#") {
+            domain = String(domain[..<fragmentIndex])
+        }
+        // Remove port
+        if let colonIndex = domain.lastIndex(of: ":") {
+            let afterColon = domain[domain.index(after: colonIndex)...]
+            if afterColon.allSatisfy(\.isNumber) {
+                domain = String(domain[..<colonIndex])
+            }
+        }
+        return domain.lowercased()
+    }
+
+    /// Simulates the classification logic from addInverseDomain
+    private func classifyInput(_ domain: String) -> (entry: String, isCIDR: Bool)? {
+        let trimmed = domain.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cidr = isValidCIDR(trimmed)
+        let entry: String
+        if cidr {
+            entry = trimmed
+        } else {
+            entry = cleanDomain(trimmed)
+            guard !entry.isEmpty else { return nil }
+        }
+        return (entry, cidr)
+    }
+
+    // MARK: - CIDR Detection
+
+    func testCIDRInputIsDetectedAsCIDR() {
+        let result = classifyInput("192.168.1.0/24")
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.entry, "192.168.1.0/24")
+        XCTAssertTrue(result!.isCIDR)
+    }
+
+    func testCIDRInputWithWhitespaceIsTrimmedAndDetected() {
+        let result = classifyInput("  10.0.0.0/8  ")
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.entry, "10.0.0.0/8")
+        XCTAssertTrue(result!.isCIDR)
+    }
+
+    func testCIDRInputPreservesExactNotation() {
+        // CIDR bypasses cleanDomain so it is NOT lowercased or modified
+        let result = classifyInput("172.16.0.0/12")
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.entry, "172.16.0.0/12")
+        XCTAssertTrue(result!.isCIDR)
+    }
+
+    // MARK: - Domain Detection
+
+    func testDomainInputIsDetectedAsDomain() {
+        let result = classifyInput("example.com")
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.entry, "example.com")
+        XCTAssertFalse(result!.isCIDR)
+    }
+
+    func testDomainInputIsCleaned() {
+        let result = classifyInput("https://Example.COM/path?q=1")
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.entry, "example.com")
+        XCTAssertFalse(result!.isCIDR)
+    }
+
+    func testDomainInputWithPort() {
+        let result = classifyInput("example.com:8080")
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.entry, "example.com")
+        XCTAssertFalse(result!.isCIDR)
+    }
+
+    func testEmptyInputReturnsNil() {
+        let result = classifyInput("")
+        XCTAssertNil(result)
+    }
+
+    func testWhitespaceOnlyInputReturnsNil() {
+        let result = classifyInput("   ")
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Deduplication
+
+    /// Simulates the deduplication check from addInverseDomain
+    private func wouldDuplicate(_ input: String, existingDomains: [String]) -> Bool {
+        guard let result = classifyInput(input) else { return false }
+        return existingDomains.contains(result.entry)
+    }
+
+    func testDuplicateCIDRIsDetected() {
+        let existing = ["10.0.0.0/8", "example.com"]
+        XCTAssertTrue(wouldDuplicate("10.0.0.0/8", existingDomains: existing))
+    }
+
+    func testDuplicateDomainIsDetected() {
+        let existing = ["10.0.0.0/8", "example.com"]
+        XCTAssertTrue(wouldDuplicate("example.com", existingDomains: existing))
+    }
+
+    func testNewCIDRIsNotDuplicate() {
+        let existing = ["10.0.0.0/8", "example.com"]
+        XCTAssertFalse(wouldDuplicate("192.168.0.0/16", existingDomains: existing))
+    }
+
+    func testNewDomainIsNotDuplicate() {
+        let existing = ["10.0.0.0/8", "example.com"]
+        XCTAssertFalse(wouldDuplicate("google.com", existingDomains: existing))
+    }
+
+    func testDuplicateDetectionWithCleanedURL() {
+        // URL that cleans to existing domain
+        let existing = ["telegram.org"]
+        XCTAssertTrue(wouldDuplicate("https://telegram.org/path", existingDomains: existing))
+    }
+
+    // MARK: - Hosts file skipping for CIDR entries
+
+    func testCIDREntryShouldBeSkippedInHostsFile() {
+        // CIDR entries have isCIDR=true, and updateHostsFile skips them with `guard !domain.isCIDR`
+        let cidrEntry = (domain: "10.0.0.0/8", isCIDR: true)
+        XCTAssertTrue(cidrEntry.isCIDR, "CIDR entries must be skipped in hosts file generation")
+    }
+
+    func testDomainEntryShouldNotBeSkippedInHostsFile() {
+        let domainEntry = (domain: "example.com", isCIDR: false)
+        XCTAssertFalse(domainEntry.isCIDR, "Domain entries should be included in hosts file generation")
     }
 }
 

--- a/Tests/VPNBypassTests/VPNBypassTests.swift
+++ b/Tests/VPNBypassTests/VPNBypassTests.swift
@@ -467,7 +467,7 @@ final class AddInverseDomainLogicTests: XCTestCase {
         guard parts.count == 2,
               isValidIP(parts[0]),
               let mask = Int(parts[1]),
-              mask >= 0 && mask <= 32 else {
+              mask >= 1 && mask <= 32 else {
             return false
         }
         return true


### PR DESCRIPTION
## Summary

- Adds CIDR/subnet notation support (e.g., `192.168.1.0/24`) to VPN Only mode entries, enabling users to route entire subnets through VPN
- Fixes input validation to reject leading zeros in IP addresses (preventing octal interpretation mismatches)
- Bumps helper version to 1.5.0 for the validation behavior change

Closes #33

## Changes

- **RouteManager.swift**: `DomainEntry` gains `isCIDR` flag (backward-compatible Codable). CIDR input bypasses `cleanDomain()` and DNS resolution, routing directly via `isNetwork: true`. Toggle re-enable fixed for CIDR entries. DNS refresh skips CIDRs. Hosts file skips CIDRs.
- **HelperTool.swift**: `isValidIP()` rejects leading zeros (octal mismatch prevention)
- **HelperProtocol.swift**: Helper version 1.4.0 → 1.5.0
- **SettingsView.swift**: Placeholder updated, amber "CIDR" badge for subnet entries, updated empty state text
- **MenuBarViews.swift**: Stat label "VPN Domains" → "VPN Entries"
- **Tests**: 39 new tests — CIDR validation (14), DomainEntry Codable (10), add-inverse-domain logic (15)

## How it works

1. User enters `192.168.1.0/24` in VPN Only domain input
2. `isValidCIDR()` validates format (rejects /0 to avoid catch-all conflict)
3. Entry stored with `isCIDR: true`, bypasses DNS resolution pipeline
4. Helper creates network route via `-net` flag (pre-existing infrastructure)
5. On VPN connect/disconnect, CIDR routes are applied/removed alongside domain routes

## Test plan

- [x] 68 unit tests pass (39 new)
- [x] Build succeeds
- [ ] Manual test: add `192.168.1.0/24` in VPN Only mode, verify route appears in `netstat -rn`
- [ ] Manual test: toggle CIDR entry off/on, verify route removed/re-added
- [ ] Manual test: existing domain entries unaffected by changes
- [ ] Manual test: app upgrade with pre-existing entries (backward compatibility)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for IP ranges using CIDR notation in VPN routing configuration, enabling more flexible network control.
  * Updated UI to display IP range entries distinctly and provide guidance for supported formats.

* **Bug Fixes**
  * Fixed IPv4 validation to properly reject octets with leading zeros.

* **Chores**
  * Bumped version to 1.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->