### PR TITLE
fix: verify helper binary on disk after SMAppService registration

### DIFF
--- a/Sources/HelperManager.swift
+++ b/Sources/HelperManager.swift
@@ -259,6 +259,7 @@ final class HelperManager: ObservableObject {
         // binary. For updates we must always go through the legacy path which does
         // the actual file copy. Only use SMAppService for first-time installs.
         let helperPath = "/Library/PrivilegedHelperTools/\(kHelperToolMachServiceName)"
+        let plistPath = "/Library/LaunchDaemons/\(kHelperToolMachServiceName).plist"
         if FileManager.default.fileExists(atPath: helperPath) {
             print("🔐 Helper exists on disk, using legacy path for update...")
             return installHelperLegacy()
@@ -271,10 +272,11 @@ final class HelperManager: ObservableObject {
             print("✅ Helper registered successfully via SMAppService")
 
             // SMAppService.register() can report success without actually placing the
-            // binary on disk (observed with enterprise security tools like Zscaler).
-            // Verify the binary exists before trusting the registration.
-            if !FileManager.default.fileExists(atPath: helperPath) {
-                print("⚠️ SMAppService reported success but helper binary not on disk, falling back to legacy install...")
+            // binary/plist on disk (observed with enterprise security tools like Zscaler).
+            // Verify both files exist before trusting the registration.
+            if !FileManager.default.fileExists(atPath: helperPath) ||
+               !FileManager.default.fileExists(atPath: plistPath) {
+                print("⚠️ SMAppService reported success but helper files missing on disk, falling back to legacy install...")
                 return installHelperLegacy()
             }
 

--- a/Sources/HelperManager.swift
+++ b/Sources/HelperManager.swift
@@ -268,12 +268,21 @@ final class HelperManager: ObservableObject {
             let service = SMAppService.daemon(plistName: "\(kHelperToolMachServiceName).plist")
             try await service.register()
 
-            installationError = nil
             print("✅ Helper registered successfully via SMAppService")
+
+            // SMAppService.register() can report success without actually placing the
+            // binary on disk (observed with enterprise security tools like Zscaler).
+            // Verify the binary exists before trusting the registration.
+            if !FileManager.default.fileExists(atPath: helperPath) {
+                print("⚠️ SMAppService reported success but helper binary not on disk, falling back to legacy install...")
+                return installHelperLegacy()
+            }
+
+            installationError = nil
             return true
         } catch {
             print("⚠️ SMAppService failed: \(error.localizedDescription)")
-            print("🔐 Falling back to legacy SMJobBless...")
+            print("🔐 Falling back to legacy install...")
             return installHelperLegacy()
         }
     }


### PR DESCRIPTION
## Summary

- After `SMAppService.register()` reports success, verify the helper binary actually exists on disk at `/Library/PrivilegedHelperTools/`
- If missing, automatically fall back to the legacy AppleScript install path (which does the actual file copy + `launchctl bootstrap`)
- Observed with enterprise security tools like Zscaler that intercept daemon registration — SMAppService registers the service metadata but never places the binary

Fixes #35

## Context

User reported helper connection failures on v2.5.0 (and v2.4.5). Diagnostics showed:
- Helper binary **not on disk** (`No such file or directory`)
- Launchd plist **not on disk**
- But launchd had the service registered (SMAppService metadata)
- Manual install via `sudo cp` + `launchctl bootstrap` worked immediately

Root cause: `SMAppService.register()` can succeed without placing the binary, especially when enterprise security software intercepts the operation.

## Test plan

- [x] 68 unit tests pass
- [x] Build succeeds
- [ ] Manual test: fresh install on clean system (no helper on disk) — should try SMAppService first, then verify
- [ ] Confirmed by reporter: manual install workaround resolved the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the helper tool installation process to better handle edge cases. The system now verifies that the tool is properly installed on disk after registration succeeds and automatically falls back to an alternative installation method if the tool is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->