### PR TITLE
ci(deps): bump deprecated GitHub Actions to current majors

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
   stale:
     runs-on: [self-hosted, macOS, ARM64]
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed in 14 days if no further activity occurs.'
           close-issue-message: 'This issue was closed because it has been stale for 14 days with no activity.'


### PR DESCRIPTION
Mechanical major-version bumps for deprecated/old GitHub Actions.

- `actions/stale: v9→v10`

Auto-merge enabled; merges once CI is green.