### PR TITLE
ci(dependabot): allow github-actions major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,39 +1,35 @@
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: /
-  schedule:
-    interval: monthly
-  commit-message:
-    prefix: ci
-  labels:
-  - ci
-  - automated
-  groups:
-    github-actions:
-      patterns:
-      - '*'
-    github_actions_security:
-      applies-to: security-updates
-      patterns:
-      - '*'
-  ignore:
-  - dependency-name: '*'
-    update-types:
-    - version-update:semver-major
-- package-ecosystem: swift
-  directory: /
-  schedule:
-    interval: weekly
-    day: monday
-  commit-message:
-    prefix: deps
-  labels:
-  - dependencies
-  - automated
-  open-pull-requests-limit: 5
-  groups:
-    swift_security:
-      applies-to: security-updates
-      patterns:
-      - '*'
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci
+    labels:
+      - ci
+      - automated
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+      github_actions_security:
+        applies-to: security-updates
+        patterns:
+          - '*'
+  - package-ecosystem: swift
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: deps
+    labels:
+      - dependencies
+      - automated
+    open-pull-requests-limit: 5
+    groups:
+      swift_security:
+        applies-to: security-updates
+        patterns:
+          - '*'


### PR DESCRIPTION
Removes the `semver-major` ignore from the `github-actions` ecosystem so action major upgrades stop silently drifting. npm/docker majors remain gated.

Auto-merge enabled; merges on green CI.