### PR TITLE
ci: select full Xcode for swift test so XCTest resolves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,22 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@v6
+      - name: Select Xcode toolchain
+        # `swift test` needs XCTest, which ships only with full Xcode — not with
+        # the Command Line Tools. Point the toolchain at an installed Xcode so
+        # XCTest resolves, and fail fast with a clear message if it's missing.
+        run: |
+          XCODE_APP=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1 || true)
+          if [ -z "$XCODE_APP" ]; then
+            echo "::error::No Xcode found in /Applications. Full Xcode (not just Command Line Tools) is required for 'swift test' because XCTest ships only with Xcode. Install Xcode on this self-hosted runner."
+            exit 1
+          fi
+          DEV_DIR="$XCODE_APP/Contents/Developer"
+          echo "Using Xcode at $XCODE_APP"
+          sudo xcode-select -s "$DEV_DIR"
+          echo "DEVELOPER_DIR=$DEV_DIR" >> "$GITHUB_ENV"
+      - name: Verify XCTest is available
+        run: xcrun --find xctest
       - name: Cache SPM
         uses: actions/cache@v5
         with:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ make run
 
 Open `Package.swift` in Xcode and run the project.
 
+> **CI note:** The `test` job (`swift test`) requires **full Xcode** on the self-hosted macOS runner — XCTest ships only with Xcode, not with the Command Line Tools. The workflow selects Xcode via `DEVELOPER_DIR` automatically and fails with a clear message if it is missing.
+
 ## Usage
 
 ### Menu Bar


### PR DESCRIPTION
## Problem

The `test` job (`swift test --enable-code-coverage`) failed on the self-hosted macOS runner (Mac mini M4) with:

```
error: no such module 'XCTest'
```

Root cause: the runner has **only the Command Line Tools** selected (`xcode-select -p` → `/Library/Developer/CommandLineTools`), and **full Xcode is not installed**. XCTest (its `XCTest.framework` / swiftmodule) ships only with full Xcode, so `swift test` cannot compile the XCTest-based tests. Verified on the runner: `xcrun --find xctest` fails, and a probe build of even a `Testing`-based test reports `no such module 'Testing'` — neither test framework is available under CLT.

## Fix

- Add a **Select Xcode toolchain** step that picks the newest installed `/Applications/Xcode*.app`, runs `xcode-select -s`, and exports `DEVELOPER_DIR`. If no Xcode is present it fails fast with an actionable `::error::` message instead of the cryptic compiler error.
- Add a **Verify XCTest is available** step (`xcrun --find xctest`).
- Document the runner requirement in the README.

## Runner requirement (action needed)

This workflow auto-selects Xcode, but **full Xcode must be installed on the self-hosted runner** for `swift test` to pass. The Mac mini currently has CLT only. Installing Xcode requires an Apple ID sign-in and cannot be automated here. Once Xcode is installed in `/Applications`, this CI passes with no further changes.