### PR TITLE
ci: auto-tag releases from conventional commits

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -78,7 +78,7 @@ jobs:
 
           if echo "$COMMITS" | grep -qE '(^|[[:space:]])BREAKING CHANGE|^[a-zA-Z]+(\([^)]*\))?!:'; then
             MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0
-          elif echo "$COMMITS" | grep -qE '^feat'; then
+          elif echo "$COMMITS" | grep -qE '^feat(\([^)]*\))?:'; then
             MINOR=$((MINOR + 1)); PATCH=0
           else
             PATCH=$((PATCH + 1))

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,112 @@
+name: Auto Tag
+
+# Conventional-commit-driven releases (the *versioning* half of the pipeline).
+#
+#   1. Commits land on `main` using Conventional Commits (feat:, fix:, …).
+#   2. On push, this scans every commit since the last `v*` tag and bumps:
+#        breaking (BREAKING CHANGE, or `type!:`) -> MAJOR
+#        feat:                                   -> MINOR
+#        anything else (fix:, chore:, …)         -> PATCH
+#   3. It creates the `vX.Y.Z` tag and then DISPATCHES `release.yml` to build the
+#      universal DMG + update the Homebrew cask.
+#
+# Why dispatch instead of relying on release.yml's own `on: push: tags: ['v*']`:
+# the tag is pushed here with GITHUB_TOKEN, and GitHub deliberately does NOT
+# trigger further workflow runs from GITHUB_TOKEN events (recursion guard). So a
+# tag push from this job lands silently and release.yml never fires. Dispatching
+# it explicitly (needs `actions: write`) closes that gap without a PAT.
+# release.yml keeps its tag trigger for manually-pushed tags.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Sources/**'
+      - 'Helper/**'
+      - 'Package.swift'
+      - 'Info.plist'
+      - 'Makefile'
+      - 'assets/**'
+      - 'VPNBypass.entitlements'
+      - '.github/workflows/auto-tag.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: auto-tag
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # create and push the tag
+  actions: write    # dispatch release.yml
+
+jobs:
+  tag:
+    name: Bump version from conventional commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compute next version
+        id: bump
+        run: |
+          LATEST=$(git tag -l "v*" --sort=-version:refname | head -1)
+          if [ -z "$LATEST" ]; then
+            echo "No existing tag; starting at v0.1.0"
+            echo "new_tag=v0.1.0" >> "$GITHUB_OUTPUT"
+            echo "version=0.1.0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          VERSION="${LATEST#v}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+          # Conventional-commit bump from $LATEST..HEAD:
+          #   breaking (BREAKING CHANGE in body, or `type!:` e.g. feat!:/fix!:) -> MAJOR
+          #   feat:                                                             -> MINOR
+          #   anything else (fix:, chore:, refactor:, …)                        -> PATCH
+          COMMITS=$(git log --format=%B "${LATEST}..HEAD")
+          if [ -z "$(git log --oneline "${LATEST}..HEAD")" ]; then
+            echo "No commits since $LATEST; nothing to release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if echo "$COMMITS" | grep -qE '(^|[[:space:]])BREAKING CHANGE|^[a-zA-Z]+(\([^)]*\))?!:'; then
+            MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0
+          elif echo "$COMMITS" | grep -qE '^feat'; then
+            MINOR=$((MINOR + 1)); PATCH=0
+          else
+            PATCH=$((PATCH + 1))
+          fi
+
+          NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "new_tag=${NEW_TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${MAJOR}.${MINOR}.${PATCH}" >> "$GITHUB_OUTPUT"
+          echo "📦 $LATEST -> $NEW_TAG"
+
+      - name: Create and push tag
+        if: steps.bump.outputs.skip != 'true'
+        run: |
+          NEW_TAG="${{ steps.bump.outputs.new_tag }}"
+          if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
+            echo "Tag $NEW_TAG already exists; skipping."
+            exit 0
+          fi
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"
+
+      - name: Dispatch release build
+        if: steps.bump.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run release.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref "${{ steps.bump.outputs.new_tag }}" \
+            -f version="${{ steps.bump.outputs.version }}"
+          echo "🚀 Dispatched release.yml for ${{ steps.bump.outputs.new_tag }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,12 @@ on:
       - 'Package.swift'
       - 'Package.resolved'
       - '.github/workflows/ci.yml'
+  # No paths filter on PRs: `test` is a required status check in the "Protect
+  # main" ruleset, so it MUST report on every PR — a path-filtered run that is
+  # skipped never reports and blocks the PR forever. Push to main stays
+  # path-filtered (above) to avoid redundant post-merge runs.
   pull_request:
     branches: [main]
-    paths:
-      - '**/*.swift'
-      - 'Package.swift'
-      - 'Package.resolved'
-      - '.github/workflows/ci.yml'
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,17 +53,24 @@ Before making changes, read these files to understand the project:
 
 ### Releasing New Versions
 
-1. Run `./scripts/bump-version.sh <version>` — updates Info.plist, README.md badge, and Casks/
-2. Update `docs/CHANGELOG.md` with release notes
-3. Commit: `git add -A && git commit -m "chore: release v<version>"`
-4. Tag and push: `git tag v<version> && git push && git push origin v<version>`
+**Releases are fully automatic from Conventional Commits — do NOT bump or tag by hand.**
 
-CI (`.github/workflows/release.yml`) does the rest automatically:
-- Builds universal DMG (arm64 + x86_64)
-- Creates GitHub Release with the DMG
+Just merge PRs to `main` with conventional commit messages. On every push to `main`,
+`.github/workflows/auto-tag.yml` scans commits since the last `v*` tag and bumps:
+- `feat:` → **minor** (e.g. 2.8.1 → 2.9.0)
+- `fix:` / `chore:` / anything else → **patch** (2.8.1 → 2.8.2)
+- `type!:` or `BREAKING CHANGE` → **major** (2.8.1 → 3.0.0)
+
+It creates the `vX.Y.Z` tag and dispatches `.github/workflows/release.yml`, which:
+- Builds the universal DMG (arm64 + x86_64) and stamps the version into Info.plist at build time
+- Creates the GitHub Release with the DMG
 - Updates the Homebrew cask in `homebrew-vpn-bypass` repo
 
-**Do NOT manually** create GitHub releases, upload DMGs, or update the Homebrew cask — CI will overwrite them.
+**Do NOT** run `bump-version.sh`, create tags, create GitHub releases, upload DMGs, or
+update the cask manually — `auto-tag.yml` + `release.yml` own the whole pipeline and will
+overwrite manual work. `bump-version.sh` is retained only for the rare manual/local build.
+
+The version badge in README.md is the dynamic `github/v/release` shield, so it needs no bump.
 
 After CI completes: `brew update && brew upgrade --cask vpn-bypass` to install locally.
 
@@ -79,7 +86,7 @@ After CI completes: `brew update && brew upgrade --cask vpn-bypass` to install l
 
 ## Learned Patterns
 
-- **Never skip `bump-version.sh`** before tagging a release. Forgetting it caused version desync in v1.8.2–v1.9.0 (#15).
+- **Releases are auto-tagged from Conventional Commits** — `.github/workflows/auto-tag.yml` computes the next version on every push to `main` (`feat:`→minor, `fix:`/other→patch, `!`/`BREAKING CHANGE`→major), tags `vX.Y.Z`, and dispatches `release.yml`. NEVER hand-tag or run `bump-version.sh` for a normal release; just merge with a conventional commit message. (`bump-version.sh` is kept only for manual/local builds — the old version-desync risk from #15 no longer applies to CI releases.)
 - **Version display is dynamic** — do NOT hardcode version strings in Swift code. The app reads from the bundle's `CFBundleShortVersionString` at runtime.
 - **Always test via Homebrew** after releasing, never trust `swift build` alone.
 - **Helperless mode is not supported.** The privileged helper is auto-installed on first launch and auto-updated on version mismatch. All helperless fallbacks (direct `/sbin/route`, AppleScript) have been removed — every route-mutating operation requires the helper.
@@ -89,7 +96,7 @@ After CI completes: `brew update && brew upgrade --cask vpn-bypass` to install l
 - **Ship universal binaries** — both the main app and the privileged helper must be universal (`arm64` + `x86_64`) so Intel Macs can launch. `swift build --arch arm64 --arch x86_64` outputs to `.build/apple/Products/Release`, while the helper needs separate arch builds plus `lipo`.
 - **Menu bar template images use ONLY the alpha channel** — luminance/color is ignored. Background alpha=0, shape alpha=255. Must be 8-bit PNG (CoreGraphics rejects 16-bit). Render from SVG via `rsvg-convert`.
 - **Settings window Dock icon** — menu bar-only apps (LSUIElement) have no Dock icon, so minimized windows vanish. Fix: toggle `NSApp.setActivationPolicy(.regular)` when settings opens, `.accessory` when it closes.
-- **CI handles releases end-to-end** — pushing a `v*` tag triggers `.github/workflows/release.yml` which builds the DMG, creates the GitHub release, AND updates the Homebrew cask. Do NOT manually create releases or update the cask — CI will overwrite them. Just commit, tag, push.
+- **CI handles releases end-to-end** — merging a Conventional Commit to `main` triggers `auto-tag.yml` (version bump + tag) which chains into `release.yml` (DMG + GitHub release + Homebrew cask). Do NOT manually create tags, releases, or update the cask — CI will overwrite them. Just merge with a `feat:`/`fix:` message. A manually-pushed `v*` tag still triggers `release.yml` directly (escape hatch).
 - **Test the stale-helper upgrade path after release** — especially with VPN already connected and an older helper still installed. Expected flow: helper preflight on startup, admin prompt if needed, helper update, route apply, and DNS refresh timer start automatically.
 - **Some VPNs route via interface link, not IP gateway** — Cisco Secure Client sets the default route to `link#N` (an interface reference) instead of an IP address. `route -n get default` shows `interface: utunX` with no `gateway:` line. VPN Only mode handles this via `iface:<interface>` convention: the helper uses `route add -host <dest> -interface utunX` instead of an IP gateway. See #26.
 - **VPN interface flaps cause spurious notifications.** `NWPathMonitor` and `ifconfig` can momentarily miss the VPN interface during network transitions. `checkVPNStatus()` must recheck after a short delay (1.5s) before committing to a disconnect state, otherwise the app fires false disconnect→reconnect notifications.


### PR DESCRIPTION
## What

Adds `auto-tag.yml` so releases are driven by **Conventional Commits** — the same pattern already used in `Pumperly`, `IBKR-Telegram`, and `SrCanario-CopyTrading` (NOT release-please / no "release PR").

On every push to `main`:
1. Scan commits since the last `v*` tag and bump the version:
   - `feat:` → **minor**
   - `fix:` / `chore:` / anything else → **patch**
   - `type!:` or `BREAKING CHANGE` → **major**
2. Create the `vX.Y.Z` tag.
3. Dispatch `release.yml` to build the universal DMG, cut the GitHub Release, and update the Homebrew cask.

## Why dispatch instead of relying on the tag trigger

`release.yml` already runs `on: push: tags: ['v*']`, but a tag pushed with `GITHUB_TOKEN` does **not** trigger downstream workflows (GitHub's recursion guard). So `auto-tag.yml` explicitly dispatches `release.yml` (`actions: write` + the existing `workflow_dispatch` `version` input). **No new secrets** — this repo has no `PAT`, and none is needed.

## Verified

- Bump logic run against live history: last tag `v2.8.1`, commits since include the merged `feat:` icon PR → computes **`v2.9.0`** ✅
- `auto-tag.yml` YAML validates; `release.yml` dispatch accepts the `version` input.

## Effect once merged

Merging this PR is itself a push to `main` containing a `feat:` (the merged icon work) since `v2.8.1`, so `auto-tag.yml` will immediately cut **v2.9.0** — shipping the new app icon. From then on, every `feat:`/`fix:` merge releases automatically.

Also updates `CLAUDE.md` to document the new flow (no manual `bump-version.sh` + tag).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated semantic versioning pipeline that analyzes commit patterns to compute release versions and automatically create tagged releases.

* **Documentation**
  * Updated release process documentation to reflect the new automatic versioning workflow and removed manual tagging procedures to streamline releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->