### PR TITLE
fix: modernize Homebrew cask depends_on (#49)

### DIFF
--- a/Casks/vpn-bypass.rb
+++ b/Casks/vpn-bypass.rb
@@ -8,10 +8,10 @@ cask "vpn-bypass" do
 
   url "https://github.com/GeiserX/VPN-Bypass/releases/download/v#{version}/VPN-Bypass-#{version}.dmg"
   name "VPN Bypass"
-  desc "macOS menu bar app to route specific traffic around VPN"
+  desc "Menu bar app to route specific traffic around VPN"
   homepage "https://github.com/GeiserX/VPN-Bypass"
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "VPN Bypass.app"
 
@@ -24,7 +24,7 @@ cask "vpn-bypass" do
 
   zap trash: [
     "~/Library/Application Support/VPNBypass",
-    "~/Library/Preferences/com.geiserx.vpn-bypass.plist",
     "~/Library/Caches/com.geiserx.vpn-bypass",
+    "~/Library/Preferences/com.geiserx.vpn-bypass.plist",
   ]
 end

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to VPN Bypass will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.1] - 2026-06-09
+
+### Fixed
+- **Homebrew cask deprecation** — Replaced the deprecated `depends_on macos: ">= :ventura"` string-comparison form with the modern `depends_on macos: :ventura` symbol form, silencing the `brew` deprecation warning. Semantics are unchanged (macOS Ventura 13 or newer). Thanks to @gcpmusic for the report (#49).
+
+## [2.9.0] - 2026-06-09
+
+### Changed
+- **New app icon & logo** — Refreshed the app icon, in-app logo, and README banner with @Tetonne's community-suggested shield design (dark-navy macOS squircle). See #39.
+
+### Fixed
+- **"Setting Up…" hang** — When the privileged helper is not yet ready, the menu now shows real VPN/network status instead of spinning on "Setting Up…" indefinitely.
+
 ## [2.8.1] - 2026-05-04
 
 ### Fixed


### PR DESCRIPTION
## What

Fixes #49 (reported by @gcpmusic): `brew` emits a deprecation warning for the cask's macOS dependency.

Replaces the deprecated string-comparison form with the modern symbol form:
```diff
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
```

**Semantics are identical** — in a Homebrew *cask*, a bare symbol is parsed with a hard-coded `>=` comparator, so both mean "macOS Ventura (13) or newer." Verified against Homebrew 5.1.15 source (`cask/dsl/depends_on.rb` passes `comparator: ">="`) and an executed `brew ruby` test: `:ventura` and `">= :ventura"` produce byte-identical requirements; Sonoma/Sequoia/Tahoe users remain allowed. This is exactly the rewrite `brew style --fix` applies (RuboCop `Homebrew/OSDependsOn`, PR Homebrew/brew#22185).

While here, cleared two pre-existing `brew style` offenses on the same cask:
- Dropped the platform word from `desc` (`Cask/Desc`).
- Alphabetized the `zap trash:` array (`Cask/ArrayAlphabetization`).

`brew style ./Casks/vpn-bypass.rb` → **no offenses detected**.

Also backfills `docs/CHANGELOG.md` with the 2.9.0 (icon) and 2.9.1 (this fix) entries.

## Note

The user-facing cask lives in the `geiserx/homebrew-vpn-bypass` tap; that copy is being fixed in lockstep. `release.yml` only rewrites `version`/`sha256`, so this `depends_on` fix is durable.