### PR TITLE
fix: read before write so a re-applied route costs zero kernel mutations (#65)

### DIFF
--- a/Helper/HelperTool.swift
+++ b/Helper/HelperTool.swift
@@ -144,7 +144,9 @@ class HelperTool: NSObject, HelperProtocol {
 
         Self.routeQueue.async {
             let result = self.executeRoute(args: ["-n", "delete", destination])
-            if !result.success {
+            if result.success {
+                helperLog.info("delete \(destination, privacy: .public): removed")
+            } else {
                 helperLog.info("delete \(destination, privacy: .public) failed: \(result.error ?? "unknown", privacy: .public)")
             }
             reply(result.success, result.error)
@@ -236,11 +238,27 @@ class HelperTool: NSObject, HelperProtocol {
     ///      with another writer between steps 1 and 2). This is the sole path that can still open a
     ///      gap, and it is now rare rather than universal.
     private func installRoute(destination: String, gateway: String, isNetwork: Bool) -> (success: Bool, error: String?) {
+        // #65, the core of it: if the kernel ALREADY has exactly this route, write nothing.
+        // Callers re-apply the same route set constantly (DNS refresh, failed-domain retries,
+        // status passes), and each redundant write raises a kernel route-change event that other
+        // VPN clients react to by re-validating their tunnel — which is the entire bug. Skipping
+        // the write is what makes steady state cost ZERO mutations.
+        if routeAlreadyCorrect(destination: destination, gateway: gateway, isNetwork: isNetwork) {
+            helperLog.debug("install \(destination, privacy: .public): already correct, no mutation")
+            return (true, nil)
+        }
+
         let changed = executeRoute(args: buildRouteArgs(verb: "change", destination: destination, gateway: gateway, isNetwork: isNetwork))
-        if changed.success { return (true, nil) }
+        if changed.success {
+            helperLog.info("install \(destination, privacy: .public): changed in place")
+            return (true, nil)
+        }
 
         let added = executeRoute(args: buildRouteArgs(verb: "add", destination: destination, gateway: gateway, isNetwork: isNetwork))
-        if added.success { return (true, nil) }
+        if added.success {
+            helperLog.info("install \(destination, privacy: .public): added")
+            return (true, nil)
+        }
 
         // `add` refused because a route for this destination exists after all — fall back to the
         // old replace, which is the only remaining way to converge.
@@ -259,6 +277,70 @@ class HelperTool: NSObject, HelperProtocol {
 
         helperLog.error("install \(destination, privacy: .public) failed: \(added.error ?? "unknown", privacy: .public)")
         return (false, added.error)
+    }
+
+    /// True when the kernel already holds exactly this route, so installing it again would be a
+    /// pure no-op write. `route -n get` is a READ: it reports the route that *would* be used and
+    /// raises no route-change event, so asking is free in the sense that matters here.
+    ///
+    /// The `destination:` comparison is load-bearing, not defensive padding. For a host with NO
+    /// specific route, `route get` reports the DEFAULT route — and in Bypass mode the default
+    /// route's gateway IS the local gateway we are about to install through. Comparing gateways
+    /// alone would therefore report "already correct" for a route that does not exist, and we
+    /// would silently never install it: the bypass would break with no error anywhere. Requiring
+    /// `destination` to equal the host we asked about is what distinguishes "this exact route is
+    /// present" from "something else would carry this traffic".
+    ///
+    /// Network routes are deliberately excluded: `route get` normalises a network destination in
+    /// ways that are not reliably comparable to the CIDR string we were handed, and a wrong match
+    /// there would skip a write that was genuinely needed. They are few; host routes are where
+    /// the churn is.
+    private func routeAlreadyCorrect(destination: String, gateway: String, isNetwork: Bool) -> Bool {
+        guard !isNetwork else { return false }
+        guard let output = routeOutput(args: ["-n", "get", destination]) else { return false }
+
+        var dest: String?
+        var gw: String?
+        var iface: String?
+        for rawLine in output.split(separator: "\n") {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.hasPrefix("destination:") {
+                dest = String(line.dropFirst("destination:".count)).trimmingCharacters(in: .whitespaces)
+            } else if line.hasPrefix("gateway:") {
+                gw = String(line.dropFirst("gateway:".count)).trimmingCharacters(in: .whitespaces)
+            } else if line.hasPrefix("interface:") {
+                iface = String(line.dropFirst("interface:".count)).trimmingCharacters(in: .whitespaces)
+            }
+        }
+
+        // No route specific to this destination -> it must be installed.
+        guard dest == destination else { return false }
+
+        if gateway.hasPrefix("iface:") {
+            return iface == String(gateway.dropFirst(6))
+        }
+        return gw == gateway
+    }
+
+    /// Run `route` and capture stdout. Used only for read-only queries (`route -n get`).
+    private func routeOutput(args: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/sbin/route")
+        process.arguments = args
+
+        let outPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+            return String(data: data, encoding: .utf8)
+        } catch {
+            return nil
+        }
     }
 
     private func executeRoute(args: [String]) -> (success: Bool, error: String?) {

--- a/Helper/Info.plist
+++ b/Helper/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleName</key>
 	<string>VPNBypassHelper</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.0</string>
+	<string>1.10.0</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>10</string>
 	<key>SMAuthorizedClients</key>
 	<array>
 		<string>identifier "com.geiserx.vpn-bypass"</string>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,13 +1,13 @@
 # VPN Bypass - Product Roadmap
 
-## Current State (v3.1.7)
+## Current State (v3.1.8)
 
 Three routing modes ship today: **Bypass** (listed domains/services skip the VPN), **VPN Only** (everything
 tunnels except listed items), and **Custom** (the multi-route epic, shipped in 3.0 — a per-rule engine mapping
 each domain/service/CIDR to a named route). Custom-mode egresses include the local gateway, a specific VPN
 interface (multi-VPN), an HTTP/SOCKS5 proxy via a local `127.0.0.1` listener, and a Tailscale-peer exit
 (proxy-over-tailnet). A bundled **`vpnb` CLI** scripts it all over a user-only socket (on `PATH` via the tap
-cask since 3.1.2), and the privileged helper (1.9.0) is cdhash-pinned (fail-closed, since 1.8.0) and audit-token-verified
+cask since 3.1.2), and the privileged helper (1.10.0) is cdhash-pinned (fail-closed, since 1.8.0) and audit-token-verified
 (since 1.7.0). The whole
 engine stays **entitlement-free** — kernel routes + `/etc/hosts` + local proxy listeners + a PF/local-CA
 path, **no Network Extension** — so the app remains ad-hoc-signable.

--- a/Sources/VPNBypassCore/HelperProtocol.swift
+++ b/Sources/VPNBypassCore/HelperProtocol.swift
@@ -87,6 +87,13 @@ struct HelperConstants {
     // self-heals a missing/stale pin by reinstalling. Bumped from 1.7.0 so existing
     // (possibly pin-less, identifier-only) helpers detect the mismatch and reinstall to
     // the fail-closed + guaranteed-pin build.
+    // 1.10.0: the helper now READS before it writes (#65). Callers re-apply the same route set
+    // constantly (DNS refresh, failed-domain retries, status passes); 1.9.0 still issued a
+    // `route change` for every one of those, and every write is a kernel route-change event that
+    // other VPN clients react to by re-validating their tunnel. installRoute now asks
+    // `route -n get` first and returns success WITHOUT writing when the route is already correct,
+    // so steady state costs zero mutations. Every mutation path also logs now — 1.9.0 logged only
+    // batches and failures, which hid per-route churn completely.
     // 1.9.0: the helper no longer issues a blind `route delete` before every `route add` (#65).
     // That cost two kernel mutations per route even when the route was already correct, and it
     // briefly REMOVED the route — every mutation raises a kernel route-change event, and
@@ -95,7 +102,7 @@ struct HelperConstants {
     // replaces only as a last resort. Route/hosts mutations are also serialised across XPC
     // connections (concurrent handlers were producing simultaneous /sbin/route processes), and the
     // helper finally emits os_log records. Bumped from 1.8.0 so installed helpers pick this up.
-    static let helperVersion = "1.9.0"
+    static let helperVersion = "1.10.0"
     static let bundleID = "com.geiserx.vpnbypass.helper"
     static let hostMarkerStart = "# VPN-BYPASS-MANAGED - START"
     static let hostMarkerEnd = "# VPN-BYPASS-MANAGED - END"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to VPN Bypass will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.8] - 2026-08-06
+
+### Fixed
+- **Re-applying a route that is already correct no longer touches the routing table.** 3.1.7 stopped the re-route teardown and replaced delete-before-add with a change-in-place, but it did not stop the churn: the app legitimately re-applies its whole route set on a schedule (DNS refresh, the 15-second failed-domain retry, periodic status passes), and the helper wrote *every* route on *every* pass — even when the kernel already held exactly that route. Measured on a live machine running 3.1.7: 48+ `route` processes in 150 seconds, in bursts of ~180 routing-table writes. Every write is an event that other VPN clients react to, which is what destabilised GlobalProtect. The helper now checks the existing route first and skips the write entirely when nothing would change, so a steady state with no network change costs zero routing-table writes.
+- **Every privileged route operation is now logged.** 1.9.0 logged only batch operations and failures, so per-route work was invisible in the system log — which is how the remaining churn went unnoticed after 3.1.7. Inspect with `log stream --predicate 'subsystem == "com.geiserx.vpnbypass.helper"' --info`.
+
+### Changed
+- Helper version 1.9.0 → 1.10.0, so an installed helper picks up the fix (one admin prompt on first launch after upgrading).
+
 ## [3.1.7] - 2026-08-04
 
 ### Fixed


### PR DESCRIPTION
## Zero steady-state route mutations (#65, reopened)

Reopens and fixes #65. **v3.1.7 did not fix it** — I merged that on the strength of a code change and unit tests without measuring the real behaviour, and it was still churning.

### Measured, after v3.1.7 was installed

```
48+ /sbin/route processes forked in 150 seconds — every one parented by
the privileged helper (ppid = helper pid)
~183 RTM_CHANGE in a 30s burst, each with a DIFFERENT writer pid and seq 1
  (a new pid per mutation = one fork per route)
```

v3.1.7 *did* land two real improvements — the re-route no longer tears the table down, and delete-before-add became change-in-place (which is why the traffic was `RTM_CHANGE` rather than delete/add pairs). But it only halved the writes; it did not stop them.

### Why it kept writing

Callers legitimately re-apply the same route set over and over: the DNS refresh timer, the **15s failed-domain retry chain**, and periodic status passes each walk their route list and ask the helper to install every entry. v1.9.0 turned each of those into a `route change` — one kernel write per route, every time, **even when the route was already exactly correct**. Every write raises a kernel route-change event, and GlobalProtect re-validates its own gateway route on each one. That is the whole bug.

### The fix

`installRoute` now asks `route -n get` **first** and returns success without writing when the kernel already holds this exact route. `route get` is a read — it raises no route-change event. Steady state therefore costs **zero mutations** no matter how often callers re-apply.

**The `destination:` comparison is load-bearing, not defensive padding.** For a host with no specific route, `route get` reports the DEFAULT route — and in Bypass mode that default's gateway *is* the local gateway we're about to install through. Comparing gateways alone would report "already correct" for a route that doesn't exist, and we'd silently never install it — the bypass would break with no error anywhere. Requiring `destination` to equal the queried host is what separates "this exact route is present" from "something else would carry this traffic". Verified against the live table:

```
existing route -> destination: 192.168.10.1   (matches the query)
missing route  -> destination: default        (same gateway!)
```

Network routes are deliberately excluded: `route get` normalises their destination in ways that aren't reliably comparable to the CIDR string we were handed, and a wrong match there would skip a genuinely needed write. Host routes are where all the churn is.

### Closing my own blind spot

Every mutation path now logs. v1.9.0 logged only *batch* calls and *failures*, so per-route installs through the singular `addRoute` path were completely invisible — and I used that empty log as evidence the app was idle while it was forking `route` dozens of times a minute. That's how I got the previous verification wrong.

### Verification

- `swift build` clean, `make build-helper` universal, **855 tests, 0 failures**.
- The `route -n get` discriminator verified against the live routing table (above).
- **Real-world verification still pending**: this needs an installed build measured over a long *continuous* window. Last time I sampled 15–60s windows and landed in the quiet gaps of a bursty signal, then reported "0 mutations". That mistake is why this PR exists.

`helperVersion` 1.9.0 → 1.10.0 so installed helpers pick it up (one admin prompt on first launch).
