### PR TITLE
fix: VPN-Only leak window, stranded catch-alls, upgrade strand, helper wedge (#65, #67)

### DIFF
--- a/Helper/HelperTool.swift
+++ b/Helper/HelperTool.swift
@@ -599,7 +599,10 @@ class HelperTool: NSObject, HelperProtocol {
             guard parts.count == 2,
                   isValidIP(parts[0]),
                   let mask = Int(parts[1]),
-                  mask >= 0 && mask <= 32 else {
+                  mask >= 1 && mask <= 32 else {
+            // /0 is the entire default route. The app-side validator already rejects it; the root
+            // daemon must never be the MORE permissive layer, or a caller that slipped past the app
+            // could hand the kernel a route that captures everything.
                 return false
             }
             return true

--- a/Helper/HelperTool.swift
+++ b/Helper/HelperTool.swift
@@ -291,35 +291,101 @@ class HelperTool: NSObject, HelperProtocol {
     /// `destination` to equal the host we asked about is what distinguishes "this exact route is
     /// present" from "something else would carry this traffic".
     ///
-    /// Network routes are deliberately excluded: `route get` normalises a network destination in
-    /// ways that are not reliably comparable to the CIDR string we were handed, and a wrong match
-    /// there would skip a write that was genuinely needed. They are few; host routes are where
-    /// the churn is.
+    /// Network routes are handled too, by comparing BOTH `destination:` and `mask:`. Excluding them
+    /// (as the first cut of this check did) left VPN Only mode churning on every single apply: its
+    /// `0.0.0.0/1` + `128.0.0.0/1` catch-alls are network routes, so they were rewritten every time
+    /// — which is exactly the leak-critical mode where a coexisting VPN client reacting to our
+    /// route-change events does the most damage. `route -n get -net <cidr>` reports the network in
+    /// `destination:` and the netmask in `mask:`, and reports the DEFAULT route (`destination:
+    /// default`, `mask: default`) when no such network route exists — so the same "did it echo back
+    /// what I asked about" discriminator that protects the host path protects this one.
     private func routeAlreadyCorrect(destination: String, gateway: String, isNetwork: Bool) -> Bool {
-        guard !isNetwork else { return false }
-        guard let output = routeOutput(args: ["-n", "get", destination]) else { return false }
+        let args = isNetwork ? ["-n", "get", "-net", destination] : ["-n", "get", destination]
+        guard let output = routeOutput(args: args) else { return false }
 
         var dest: String?
+        var mask: String?
         var gw: String?
         var iface: String?
+        var flags = ""
         for rawLine in output.split(separator: "\n") {
             let line = rawLine.trimmingCharacters(in: .whitespaces)
             if line.hasPrefix("destination:") {
                 dest = String(line.dropFirst("destination:".count)).trimmingCharacters(in: .whitespaces)
+            } else if line.hasPrefix("mask:") {
+                mask = String(line.dropFirst("mask:".count)).trimmingCharacters(in: .whitespaces)
             } else if line.hasPrefix("gateway:") {
                 gw = String(line.dropFirst("gateway:".count)).trimmingCharacters(in: .whitespaces)
             } else if line.hasPrefix("interface:") {
                 iface = String(line.dropFirst("interface:".count)).trimmingCharacters(in: .whitespaces)
+            } else if line.hasPrefix("flags:") {
+                flags = String(line.dropFirst("flags:".count)).trimmingCharacters(in: .whitespaces)
             }
         }
 
-        // No route specific to this destination -> it must be installed.
-        guard dest == destination else { return false }
+        // The route we matched must be a real, static entry of the KIND we are installing — not an
+        // ephemeral clone and not a wider route that merely covers this address.
+        //
+        // This is the subtle one. The default route carries PRCLONING, so macOS mints short-lived
+        // host routes to arbitrary destinations that inherit the parent's gateway. Such a clone
+        // echoes back `destination: <our exact IP>` with `gateway: <local gateway>` — and in Bypass
+        // mode the local gateway is precisely what we were about to install. Without this guard we
+        // would call that "already correct", skip the write, record the route as applied, and then
+        // watch the clone expire — leaving the destination silently on whatever the parent route
+        // says. No error, no log, no failed verification: exactly the silent bypass failure the
+        // destination check above exists to prevent.
+        guard !flags.contains("WASCLONED"),
+              !flags.contains("REJECT"),
+              !flags.contains("BLACKHOLE") else { return false }
+        if isNetwork {
+            guard !flags.contains("HOST") else { return false }
+        } else {
+            guard flags.contains("HOST") else { return false }
+        }
+
+        if isNetwork {
+            // `route get -net 10.0.0.0/8` echoes `destination: 10.0.0.0` + `mask: 255.0.0.0`, so the
+            // CIDR we were handed has to be split and the prefix expanded before comparing. BOTH must
+            // match: destination alone would treat 0.0.0.0/1 and a 0.0.0.0/8 as the same route.
+            guard let (network, prefix) = RouteCIDR.parse(destination),
+                  dest == network,
+                  mask == RouteCIDR.netmaskString(prefixLength: prefix)
+            else { return false }
+        } else {
+            // No route specific to this host -> it must be installed. (For a host with no route,
+            // `route get` reports the DEFAULT route, whose gateway in Bypass mode is the same local
+            // gateway we are about to install through — so this check, not the gateway one, is what
+            // stops us silently skipping a route that does not exist.)
+            guard dest == destination else { return false }
+        }
 
         if gateway.hasPrefix("iface:") {
             return iface == String(gateway.dropFirst(6))
         }
         return gw == gateway
+    }
+
+    /// Wait for `process`, but never longer than `timeout`. On expiry the process is terminated and
+    /// `false` is returned.
+    ///
+    /// Every route/hosts mutation runs on ONE serial queue (see `routeQueue`), so an unbounded
+    /// `waitUntilExit()` means a single wedged `/sbin/route` blocks every later add, remove, batch
+    /// and hosts update for the lifetime of the helper — with no watchdog and no recovery short of
+    /// restarting a root daemon. Bounding the wait keeps a stuck child from taking the pipeline
+    /// down with it; the caller sees an ordinary failure and can retry.
+    private func waitBounded(_ process: Process, timeout: TimeInterval = 10) -> Bool {
+        let done = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            process.waitUntilExit()
+            done.signal()
+        }
+        if done.wait(timeout: .now() + timeout) == .timedOut {
+            helperLog.error("route command exceeded \(timeout, privacy: .public)s — terminating")
+            process.terminate()
+            _ = done.wait(timeout: .now() + 2)
+            return false
+        }
+        return true
     }
 
     /// Run `route` and capture stdout. Used only for read-only queries (`route -n get`).
@@ -335,8 +401,7 @@ class HelperTool: NSObject, HelperProtocol {
         do {
             try process.run()
             let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-            process.waitUntilExit()
-            guard process.terminationStatus == 0 else { return nil }
+            guard waitBounded(process), process.terminationStatus == 0 else { return nil }
             return String(data: data, encoding: .utf8)
         } catch {
             return nil
@@ -354,8 +419,10 @@ class HelperTool: NSObject, HelperProtocol {
         
         do {
             try process.run()
-            process.waitUntilExit()
-            
+            guard waitBounded(process) else {
+                return (false, "route command timed out")
+            }
+
             if process.terminationStatus == 0 {
                 return (true, nil)
             } else {

--- a/Helper/Info.plist
+++ b/Helper/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleName</key>
 	<string>VPNBypassHelper</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.10.0</string>
+	<string>1.11.0</string>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>SMAuthorizedClients</key>
 	<array>
 		<string>identifier "com.geiserx.vpn-bypass"</string>

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ VPN Bypass intelligently routes selected services directly to the internet while
 ## Features
 
 - 🎯 **Menu bar app** — quick access to status, mode, and controls
-- 🧭 **Three routing modes** — **Bypass** (listed traffic skips the VPN), **VPN Only** (everything uses the VPN except what you list), and **Custom** (per-rule routing)
+- 🧭 **Three routing modes** — **Bypass** *(default)*: everything uses the VPN **except** the domains you list. **VPN Only**: the inverse — everything goes **direct** except the domains you list, which are forced through the VPN. **Custom**: per-rule routing.
 - 🌐 **Custom domains & built-in services** — add any domain, or toggle bundled service packs (Telegram, YouTube, WhatsApp, Spotify, Tailscale, and more)
 - 🧩 **Custom rules & routes** — map each domain, suffix, IP/CIDR, service, or process to a specific route; first match wins
 - 🔀 **Multiple egresses** — send traffic out the local gateway, a specific VPN interface (multi-VPN), an **HTTP/SOCKS5 proxy**, or a **Tailscale peer** used as an exit

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # VPN Bypass - Product Roadmap
 
-## Current State (v3.1.8)
+## Current State (v3.1.9)
 
 Three routing modes ship today: **Bypass** (everything uses the VPN except the listed domains/services,
 which skip it), **VPN Only** (the inverse — everything goes direct except the listed items, which are
@@ -8,7 +8,7 @@ forced through the VPN), and **Custom** (the multi-route epic, shipped in 3.0 �
 each domain/service/CIDR to a named route). Custom-mode egresses include the local gateway, a specific VPN
 interface (multi-VPN), an HTTP/SOCKS5 proxy via a local `127.0.0.1` listener, and a Tailscale-peer exit
 (proxy-over-tailnet). A bundled **`vpnb` CLI** scripts it all over a user-only socket (on `PATH` via the tap
-cask since 3.1.2), and the privileged helper (1.10.0) is cdhash-pinned (fail-closed, since 1.8.0) and audit-token-verified
+cask since 3.1.2), and the privileged helper (1.11.0) is cdhash-pinned (fail-closed, since 1.8.0) and audit-token-verified
 (since 1.7.0). The whole
 engine stays **entitlement-free** — kernel routes + `/etc/hosts` + local proxy listeners + a PF/local-CA
 path, **no Network Extension** — so the app remains ad-hoc-signable.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,8 +2,9 @@
 
 ## Current State (v3.1.8)
 
-Three routing modes ship today: **Bypass** (listed domains/services skip the VPN), **VPN Only** (everything
-tunnels except listed items), and **Custom** (the multi-route epic, shipped in 3.0 — a per-rule engine mapping
+Three routing modes ship today: **Bypass** (everything uses the VPN except the listed domains/services,
+which skip it), **VPN Only** (the inverse — everything goes direct except the listed items, which are
+forced through the VPN), and **Custom** (the multi-route epic, shipped in 3.0 — a per-rule engine mapping
 each domain/service/CIDR to a named route). Custom-mode egresses include the local gateway, a specific VPN
 interface (multi-VPN), an HTTP/SOCKS5 proxy via a local `127.0.0.1` listener, and a Tailscale-peer exit
 (proxy-over-tailnet). A bundled **`vpnb` CLI** scripts it all over a user-only socket (on `PATH` via the tap

--- a/Sources/VPNBypassCore/ClassicRouteCompiler.swift
+++ b/Sources/VPNBypassCore/ClassicRouteCompiler.swift
@@ -71,9 +71,22 @@ enum ClassicRouteCompiler {
 
         // VPN Only: catch-all through the local gateway (0.0.0.0/1 + 128.0.0.0/1 cover all IPv4
         // with higher specificity than the default route), then inverse CIDRs through the VPN.
+        //
+        // INSTALL ORDER IS LEAK-CRITICAL. The helper writes this array strictly in order, so the
+        // catch-alls are deferred to the very END rather than emitted here. Installing them first
+        // — as this did originally — pointed ALL traffic at the local gateway before any of the
+        // listed destinations had their VPN route yet, so for the length of the apply (hundreds of
+        // routes, each a subprocess) the exact destinations the user asked to protect fell through
+        // to the clear. The apply made things worse before it made them better. Emitting them last
+        // means the VPN routes are already in place the instant the catch-alls take effect.
+        //
+        // This mirrors teardown, which already removes catch-alls FIRST (see removeAllRoutes and
+        // destinationsToUnstrand) so that traffic falls back to the VPN default, not out of it.
+        // Same principle, opposite end: the catch-alls are the last thing on and the first thing off.
+        var deferredCatchAlls: [Route] = []
         if isInverse {
-            routesToAdd.append(Route(destination: "0.0.0.0/1", gateway: localGateway, isNetwork: true, source: "VPN Only catch-all"))
-            routesToAdd.append(Route(destination: "128.0.0.0/1", gateway: localGateway, isNetwork: true, source: "VPN Only catch-all"))
+            deferredCatchAlls.append(Route(destination: "0.0.0.0/1", gateway: localGateway, isNetwork: true, source: "VPN Only catch-all"))
+            deferredCatchAlls.append(Route(destination: "128.0.0.0/1", gateway: localGateway, isNetwork: true, source: "VPN Only catch-all"))
             seenDestinations.insert("0.0.0.0/1")
             seenDestinations.insert("128.0.0.0/1")
             allSourceEntries.append(SourceEntry(destination: "0.0.0.0/1", gateway: localGateway, source: "VPN Only catch-all"))
@@ -124,6 +137,10 @@ enum ClassicRouteCompiler {
                 routesToAdd.append(Route(destination: sr.range, gateway: localGateway, isNetwork: true, source: sr.source))
             }
         }
+
+        // Catch-alls last (see the comment where they are built): the VPN routes must already be
+        // installed before all remaining traffic is pointed at the local gateway.
+        routesToAdd.append(contentsOf: deferredCatchAlls)
 
         return Build(routesToAdd: routesToAdd, allSourceEntries: allSourceEntries)
     }

--- a/Sources/VPNBypassCore/HelperManager.swift
+++ b/Sources/VPNBypassCore/HelperManager.swift
@@ -640,10 +640,15 @@ final class HelperManager: ObservableObject {
             ]
         }
         let allDests = routes.map { $0.destination }
-        // Budget 0.25s per route: helper does delete-before-add (2 subprocess calls
-        // at ~0.07s each ≈ 0.14s/route). 0.1s/route was too tight and caused timeouts
-        // for batches above ~250 routes, dropping all routes as failed.
-        let timeout = xpcTimeout + Double(routes.count) * 0.25
+        // Budget 0.6s per route. Since 1.10.0 the helper reads before it writes, so the worst
+        // realistic path for a route that must actually be installed is THREE subprocesses
+        // (`route get` + a failed `route change` + `route add`), not the two the old 0.25s figure
+        // assumed. Spawn cost is also far above the 0.07s that figure was calibrated against on
+        // machines running endpoint-security agents — which is precisely the population running a
+        // corporate VPN. Under-budgeting here does not just slow things down: the batch reports as
+        // indeterminate, the connection is dropped, and the retry queues behind the abandoned work.
+        // A steady-state re-apply costs one read and no writes, so this ceiling is rarely reached.
+let timeout = xpcTimeout + Double(routes.count) * 0.6
         // On a DEADLINE timeout (not an XPC error — the call DID reach the helper), the helper may
         // be slow rather than dead and have installed some/all routes without confirming. Reporting
         // them as failed strands orphaned kernel routes the app never tracks — a leak that survives

--- a/Sources/VPNBypassCore/HelperProtocol.swift
+++ b/Sources/VPNBypassCore/HelperProtocol.swift
@@ -160,3 +160,38 @@ enum HelperAuthPolicy {
         return isValidCDHash ? trimmed : nil
     }
 }
+
+/// CIDR helpers shared by the app and the privileged helper.
+///
+/// These live here, rather than in `HelperTool.swift`, specifically so they are testable: the helper
+/// target is a root LaunchDaemon that is never linked into the test bundle, whereas this file is
+/// compiled into both. The helper's `routeAlreadyCorrect` depends on getting these exactly right —
+/// a wrong netmask makes it skip a route write that was genuinely needed, which is silent.
+public enum RouteCIDR {
+    /// Split `"10.0.0.0/8"` into `("10.0.0.0", 8)`. Returns nil for anything that is not a
+    /// well-formed IPv4 CIDR with a canonical, in-range prefix.
+    public static func parse(_ cidr: String) -> (network: String, prefixLength: Int)? {
+        let parts = cidr.split(separator: "/", omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return nil }
+        let network = String(parts[0])
+        let prefixText = String(parts[1])
+        // Reject non-canonical forms ("08", "+8") so they can never round-trip to a different value
+        // than the one the caller believes it asked for.
+        guard let prefix = Int(prefixText), String(prefix) == prefixText, (0...32).contains(prefix) else { return nil }
+        let octets = network.split(separator: ".", omittingEmptySubsequences: false)
+        guard octets.count == 4 else { return nil }
+        for octet in octets {
+            guard let value = Int(octet), String(value) == octet, (0...255).contains(value) else { return nil }
+        }
+        return (network, prefix)
+    }
+
+    /// Expand a prefix length into the dotted netmask `route(8)` prints, e.g. 1 -> "128.0.0.0",
+    /// 8 -> "255.0.0.0", 24 -> "255.255.255.0". A /0 is reported by `route` as "default", not
+    /// "0.0.0.0", so it is returned as such to match what we would be comparing against.
+    public static func netmaskString(prefixLength: Int) -> String {
+        guard (1...32).contains(prefixLength) else { return "default" }
+        let mask = UInt32.max << (32 - UInt32(prefixLength))
+        return "\((mask >> 24) & 0xFF).\((mask >> 16) & 0xFF).\((mask >> 8) & 0xFF).\(mask & 0xFF)"
+    }
+}

--- a/Sources/VPNBypassCore/HelperProtocol.swift
+++ b/Sources/VPNBypassCore/HelperProtocol.swift
@@ -87,6 +87,16 @@ struct HelperConstants {
     // self-heals a missing/stale pin by reinstalling. Bumped from 1.7.0 so existing
     // (possibly pin-less, identifier-only) helpers detect the mismatch and reinstall to
     // the fail-closed + guaranteed-pin build.
+    // 1.11.0: fixes a way the 1.10.0 read-before-write check could skip a route it should have
+    // written. It ignored `flags:` entirely, so a kernel-CLONED route (the default route carries
+    // PRCLONING, so macOS mints ephemeral host routes inheriting the parent's gateway) echoed back
+    // our exact destination with a matching gateway and was accepted as "already correct" — we
+    // skipped the write, recorded the route as applied, and the clone then expired. Silent. It now
+    // rejects WASCLONED/REJECT/BLACKHOLE and requires the matched route to be the KIND being
+    // installed. Network routes are no longer excluded from the check either (they were, so VPN
+    // Only rewrote both catch-alls on every apply). Also bounds the wait on every `route`
+    // subprocess — since 1.9.0 one wedged child would block the whole serial mutation queue for the
+    // life of the daemon — and rejects /0 at the privileged boundary, which the app already did.
     // 1.10.0: the helper now READS before it writes (#65). Callers re-apply the same route set
     // constantly (DNS refresh, failed-domain retries, status passes); 1.9.0 still issued a
     // `route change` for every one of those, and every write is a kernel route-change event that
@@ -102,7 +112,7 @@ struct HelperConstants {
     // replaces only as a last resort. Route/hosts mutations are also serialised across XPC
     // connections (concurrent handlers were producing simultaneous /sbin/route processes), and the
     // helper finally emits os_log records. Bumped from 1.8.0 so installed helpers pick this up.
-    static let helperVersion = "1.10.0"
+    static let helperVersion = "1.11.0"
     static let bundleID = "com.geiserx.vpnbypass.helper"
     static let hostMarkerStart = "# VPN-BYPASS-MANAGED - START"
     static let hostMarkerEnd = "# VPN-BYPASS-MANAGED - END"

--- a/Sources/VPNBypassCore/NotificationManager.swift
+++ b/Sources/VPNBypassCore/NotificationManager.swift
@@ -17,13 +17,23 @@ final class NotificationManager: NSObject, ObservableObject, UNUserNotificationC
     @Published var notifyOnRouteFailure = true
     @Published var isAuthorized = false
     
-    private let notificationCenter = UNUserNotificationCenter.current()
+    /// Nil under XCTest. `UNUserNotificationCenter.current()` traps when the process has no app
+    /// bundle ("bundleProxyForCurrentProcess is nil"), so merely *touching* this singleton from a
+    /// test aborts the entire suite with signal 6. Guarding here, rather than at each call site,
+    /// means any code path is free to notify without knowing whether it is running under test —
+    /// which matters because the paths that most need to notify are error paths, and those are
+    /// exactly the ones tests drive. Mirrors the `underTests` redirect already used for config
+    /// storage in RouteManager.
+    private static let isUnderTests = NSClassFromString("XCTestCase") != nil
+        || ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    private let notificationCenter: UNUserNotificationCenter? =
+        NotificationManager.isUnderTests ? nil : .current()
     
     private override init() {
         super.init()
         
         // Set ourselves as delegate to handle foreground notifications
-        notificationCenter.delegate = self
+        notificationCenter?.delegate = self
         
         // Load saved preferences
         loadPreferences()
@@ -62,6 +72,7 @@ final class NotificationManager: NSObject, ObservableObject, UNUserNotificationC
     
     func requestAuthorization() async {
         do {
+            guard let notificationCenter else { return }
             let granted = try await notificationCenter.requestAuthorization(options: [.alert, .sound, .badge])
             isAuthorized = granted
             
@@ -80,11 +91,13 @@ final class NotificationManager: NSObject, ObservableObject, UNUserNotificationC
     }
     
     func updateAuthorizationStatus() async {
+        guard let notificationCenter else { return }
         let settings = await notificationCenter.notificationSettings()
         isAuthorized = settings.authorizationStatus == .authorized
     }
     
     func checkAuthorizationStatus() async -> Bool {
+        guard let notificationCenter else { return false }
         let settings = await notificationCenter.notificationSettings()
         let authorized = settings.authorizationStatus == .authorized
         isAuthorized = authorized
@@ -140,11 +153,32 @@ final class NotificationManager: NSObject, ObservableObject, UNUserNotificationC
     
     func notifyRouteVerificationFailed(route: String, reason: String) {
         guard notificationsEnabled && notifyOnRouteFailure else { return }
-        
+
         sendNotification(
             title: String(localized: "Route Verification Failed"),
             body: "\(route): \(reason)",
             identifier: "route-failed-\(route.hashValue)"
+        )
+    }
+
+    /// Nothing at all could be enforced — the app is configured but not doing anything.
+    ///
+    /// This is the failure a user most needs to hear about, and it was the ONE case guaranteed to be
+    /// silent: `notifyRoutesApplied` is gated both on a non-zero success count and on
+    /// `notifyOnRoutesApplied`, which defaults OFF — so a total failure notified nothing, while
+    /// *partial* failures did get through. Every early return in the apply paths (no gateway, helper
+    /// not ready, VPN Only without a VPN gateway, VPN Only refused under GlobalProtect) now lands
+    /// here instead of only writing a log line the user has no reason to open.
+    ///
+    /// Gated on `notifyOnRouteFailure`, which defaults ON. The identifier is stable per reason so a
+    /// repeating condition coalesces into one notification rather than nagging on every retry.
+    func notifyEnforcementFailed(reason: String) {
+        guard notificationsEnabled && notifyOnRouteFailure else { return }
+
+        sendNotification(
+            title: String(localized: "VPN Bypass isn't routing anything"),
+            body: reason,
+            identifier: "enforcement-failed-\(reason.hashValue)"
         )
     }
     
@@ -167,6 +201,7 @@ final class NotificationManager: NSObject, ObservableObject, UNUserNotificationC
         let uniqueId = "\(identifier)-\(Date().timeIntervalSince1970)"
         let request = UNNotificationRequest(identifier: uniqueId, content: content, trigger: nil)
         
+        guard let notificationCenter else { return }
         notificationCenter.add(request) { error in
             if let error = error {
                 // The completion runs off the main actor; hop back to log (and pre-format

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -1050,6 +1050,9 @@ final class RouteManager: ObservableObject {
 
         guard let gateway = localGateway else {
             log(.error, "No local gateway available")
+            NotificationManager.shared.notifyEnforcementFailed(
+                reason: String(localized: "No network gateway was detected, so no routes could be applied.")
+            )
             return
         }
 
@@ -1069,6 +1072,9 @@ final class RouteManager: ObservableObject {
         if isInverse {
             guard let vpnGw = vpnGateway else {
                 log(.error, "VPN Only mode requires a VPN gateway (is VPN connected?)")
+                NotificationManager.shared.notifyEnforcementFailed(
+                    reason: String(localized: "VPN Only needs a connected VPN. Nothing is being routed through the VPN right now.")
+                )
                 return
             }
             log(.info, "VPN Only mode: bypass-all via \(gateway), VPN domains via \(vpnGw)")
@@ -1237,6 +1243,9 @@ final class RouteManager: ObservableObject {
             }
         } else {
             log(.error, "Cannot add routes: helper not ready (\(HelperManager.shared.helperState.statusText))")
+            NotificationManager.shared.notifyEnforcementFailed(
+                reason: String(localized: "The privileged helper isn't ready, so no routes could be applied.")
+            )
             return
         }
 
@@ -2684,7 +2693,24 @@ final class RouteManager: ObservableObject {
                 // cleanup. A real gateway change is still applied — in place, without a window
                 // where the route is absent, which also removes a brief VPN-Only leak window
                 // the teardown used to open.
-                await applyAllRoutesInternal(sendNotification: false)
+                // forceReassert: re-assert every route against the KERNEL, not just against our
+                // in-memory model.
+                //
+                // 3.1.7 removed `removeAllRoutes()` from this path to stop the churn, but that
+                // teardown had a second, unnoticed job: it re-issued every route unconditionally,
+                // so any divergence between our model and the actual routing table self-healed on
+                // every interface change — exactly the event during which the kernel purges routes
+                // bound to a departing utun. Without it, `shouldSkipReapply` compares desired
+                // against our own bookkeeping, sees them equal, and performs ZERO kernel operations
+                // while the kernel no longer holds the routes at all. The only remaining recovery
+                // was the manual Refresh button.
+                //
+                // forceReassert restores that self-healing, and since 1.10.0 it is nearly free:
+                // the helper reads each route first and writes only the ones that actually differ,
+                // so a fully-correct set costs N reads and zero mutations — no route-change events,
+                // nothing for a coexisting VPN client to react to. This is what makes the 3.1.7 and
+                // 3.1.8 changes compose instead of cancelling each other out.
+                await applyAllRoutesInternal(sendNotification: false, forceReassert: true)
             }
         } else if localGateway == nil {
             log(.error, "Re-route needed but no gateway detected")

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -60,10 +60,12 @@ final class RouteManager: ObservableObject {
     private var lastTailscaleSelfFingerprint: String?
     
     
-    private var dnsCacheURL: URL {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        return appSupport.appendingPathComponent("VPNBypass/dns-cache.json")
-    }
+    /// Set once in init from the SAME directory as `configURL`, so it follows the under-test
+    /// redirect. It used to be a computed property that always resolved to the real Application
+    /// Support path, which meant every `swift test` run read — and via saveDNSCache could write —
+    /// the developer's live DNS cache. `configURL` was already fixed for exactly this reason; this
+    /// was the same hole in a sibling property that never got the same treatment.
+    private let dnsCacheURL: URL
     
     /// Public accessor for UI to display detected DNS server
     var detectedDNSServerDisplay: String? {
@@ -127,6 +129,7 @@ final class RouteManager: ObservableObject {
         }
         try? FileManager.default.createDirectory(at: appDir, withIntermediateDirectories: true)
         configURL = appDir.appendingPathComponent("config.json")
+        dnsCacheURL = appDir.appendingPathComponent("dns-cache.json")
     }
     
     // MARK: - Public API
@@ -1037,9 +1040,37 @@ final class RouteManager: ObservableObject {
     /// route monitor and tears the tunnel down (the original incident), so EVERY
     /// route-applying path must refuse it. Returns true (and logs) when the apply
     /// should be skipped.
+    /// Catch-alls this app currently believes it owns. Used by the GlobalProtect refusal so it can
+    /// remove what is already installed rather than only declining to add more.
+    private var installedCatchAllDestinations: [String] {
+        let catchAlls = Set(RouteCompiler.catchAllDestinations)
+        return activeRoutes.map { $0.destination }.filter { catchAlls.contains($0) }
+    }
+
     private func refuseVPNOnlyUnderGlobalProtect() -> Bool {
         guard config.routingMode == .vpnOnly, vpnType == .globalProtect else { return false }
         log(.error, "VPN Only mode is disabled under GlobalProtect — its catch-all routes would tear down the GP tunnel. Use Bypass mode instead.")
+
+        // Refusing to ADD is not enough on its own. GlobalProtect can come up *after* VPN Only has
+        // already installed its catch-alls (vpnType is detected from running processes, so it flips
+        // mid-session), and the flap suppressor can turn a VPN swap into "still connected, new
+        // interface" so the disconnect teardown never runs. The refusal then returned early and left
+        // `0.0.0.0/1` + `128.0.0.0/1` pointing at the LOCAL gateway — more specific than GP's
+        // default, so 100% of traffic silently left the tunnel while the app reported itself
+        // healthy, and nothing would ever remove them. A guard that declines to add but tolerates
+        // what is already there is not a guard.
+        let stranded = installedCatchAllDestinations
+        if !stranded.isEmpty {
+            log(.warning, "Removing \(stranded.count) stranded VPN Only catch-all route(s) — they would route all traffic around GlobalProtect")
+            Task { @MainActor in
+                let result = await self.removeRoutesBatchVia(stranded)
+                let removed = Set(stranded).subtracting(result.failedDestinations)
+                self.activeRoutes.removeAll { removed.contains($0.destination) }
+                NotificationManager.shared.notifyEnforcementFailed(
+                    reason: String(localized: "VPN Only isn't available while GlobalProtect is connected. Its catch-all routes were removed so your traffic stays in the tunnel. Switch to Bypass mode.")
+                )
+            }
+        }
         return true
     }
 

--- a/Sources/VPNBypassCore/VPNBypassApp.swift
+++ b/Sources/VPNBypassCore/VPNBypassApp.swift
@@ -41,6 +41,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var networkMonitor: NWPathMonitor?
     private var refreshTimer: Timer?
     private var watchdogTimer: Timer?
+    /// Retained so the SIGTERM/SIGINT sources stay alive for the process lifetime.
+    private var terminationSignalSources: [DispatchSourceSignal] = []
     private var lastPathStatus: NWPath.Status?
     private var lastInterfaceTypes: Set<NWInterface.InterfaceType> = []
     private var lastInterfaceNames: Set<String> = []
@@ -118,8 +120,43 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         // Start watchdog timer (every 12 hours) to ensure long-term stability
         startWatchdog()
+
+        installTerminationSignalHandler()
     }
-    
+
+    /// Run the same teardown on SIGTERM that a normal Quit runs.
+    ///
+    /// `applicationShouldTerminate` is only invoked for the Quit AppleEvent / `NSApp.terminate`.
+    /// It is NOT invoked for SIGTERM — and SIGTERM is exactly what the Homebrew cask's preflight
+    /// sends (`pkill -x VPNBypass`) on every upgrade. Because `activeRoutes` lives only in memory
+    /// and nothing reconciles against the kernel, an upgrade previously left the entire route set
+    /// installed but *untracked*: the replacement binary started with an empty model, so no later
+    /// cleanup could ever remove them. In VPN Only that strands the `0.0.0.0/1`+`128.0.0.0/1`
+    /// catch-alls pointing at the local gateway — every subsequent connection silently leaves the
+    /// tunnel while the app reports itself healthy. That is the most likely mechanism behind the
+    /// "app is on but my public IP is my real one" reports.
+    ///
+    /// `signal(SIGTERM, SIG_IGN)` is required: the DispatchSource only observes the signal, it does
+    /// not suppress the default terminate-immediately disposition.
+    ///
+    /// This does not cover `kill -9` or a crash — nothing in-process can. The durable fix is a
+    /// helper-side journal swept at RunAtLoad, tracked separately.
+    private func installTerminationSignalHandler() {
+        for sig in [SIGTERM, SIGINT] {
+            signal(sig, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(signal: sig, queue: .main)
+            source.setEventHandler {
+                Task { @MainActor in
+                    await RouteManager.shared.cleanupOnQuit()
+                    exit(0)
+                }
+            }
+            source.resume()
+            terminationSignalSources.append(source)
+        }
+    }
+
+
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         // Hide all UI immediately so quit feels instant
         NSApp.windows.forEach { $0.orderOut(nil) }

--- a/Tests/VPNBypassTests/ClassicRouteCompilerTests.swift
+++ b/Tests/VPNBypassTests/ClassicRouteCompilerTests.swift
@@ -101,15 +101,23 @@ final class ClassicRouteCompilerTests: XCTestCase {
 
     // MARK: - VPN Only mode
 
-    func testVPNOnlyInjectsCatchAllThroughLocalGatewayFirst() {
+    /// The catch-alls must be installed LAST, and this ordering is leak-critical rather than
+    /// cosmetic. The helper writes `routesToAdd` strictly in order, one subprocess per route, so
+    /// emitting the catch-alls first pointed ALL traffic at the local gateway while the listed
+    /// destinations still had no VPN route — the exact destinations the user asked to protect went
+    /// out in the clear for the length of the apply. Teardown already removes catch-alls first (so
+    /// traffic falls back INTO the VPN default); this is the same principle at the other end.
+    ///
+    /// Note `allSourceEntries` (ownership bookkeeping, not install order) is unchanged.
+    func testVPNOnlyInstallsCatchAllLastSoVPNRoutesLandFirst() {
         let b = C.build(isInverse: true, localGateway: local, routeGateway: vpn,
                         inverseCIDRs: [],
                         resolvedGroups: [C.ResolvedGroup(source: "x.com", ips: ["3.3.3.3"])],
                         serviceRanges: [])
         XCTAssertEqual(b.routesToAdd, [
+            route("3.3.3.3", vpn, false, "x.com"),   // domain IP rides the VPN gateway — installed FIRST
             route("0.0.0.0/1", local, true, "VPN Only catch-all"),
             route("128.0.0.0/1", local, true, "VPN Only catch-all"),
-            route("3.3.3.3", vpn, false, "x.com"),   // domain IP rides the VPN gateway
         ])
         XCTAssertEqual(b.allSourceEntries, [
             entry("0.0.0.0/1", local, "VPN Only catch-all"),
@@ -118,14 +126,32 @@ final class ClassicRouteCompilerTests: XCTestCase {
         ])
     }
 
-    func testVPNOnlyInverseCIDRsRideRouteGatewayAfterCatchAll() {
+    func testVPNOnlyInverseCIDRsAreInstalledBeforeTheCatchAll() {
         let b = C.build(isInverse: true, localGateway: local, routeGateway: vpn,
                         inverseCIDRs: ["172.16.0.0/12"], resolvedGroups: [], serviceRanges: [])
         XCTAssertEqual(b.routesToAdd, [
+            route("172.16.0.0/12", vpn, true, "172.16.0.0/12"),
             route("0.0.0.0/1", local, true, "VPN Only catch-all"),
             route("128.0.0.0/1", local, true, "VPN Only catch-all"),
-            route("172.16.0.0/12", vpn, true, "172.16.0.0/12"),
         ])
+    }
+
+    /// Guards the invariant directly, independent of the exact route set: whatever else is being
+    /// installed, no catch-all may precede a non-catch-all.
+    func testNoCatchAllIsInstalledBeforeAnyProtectedRoute() {
+        let b = C.build(isInverse: true, localGateway: local, routeGateway: vpn,
+                        inverseCIDRs: ["172.16.0.0/12", "10.1.0.0/16"],
+                        resolvedGroups: [C.ResolvedGroup(source: "a.com", ips: ["4.4.4.4", "5.5.5.5"])],
+                        serviceRanges: [])
+        let catchAlls: Set<String> = ["0.0.0.0/1", "128.0.0.0/1"]
+        let firstCatchAll = b.routesToAdd.firstIndex { catchAlls.contains($0.destination) }
+        let lastProtected = b.routesToAdd.lastIndex { !catchAlls.contains($0.destination) }
+        XCTAssertNotNil(firstCatchAll, "VPN Only must install catch-alls")
+        if let first = firstCatchAll, let last = lastProtected {
+            XCTAssertGreaterThan(first, last,
+                "every VPN-bound route must be installed before the first catch-all, or traffic to "
+                + "those destinations egresses the local gateway for the duration of the apply")
+        }
     }
 
     func testVPNOnlyDuplicateInverseCIDRDeduped() {

--- a/Tests/VPNBypassTests/RouteCIDRTests.swift
+++ b/Tests/VPNBypassTests/RouteCIDRTests.swift
@@ -1,0 +1,94 @@
+// RouteCIDRTests.swift
+// Coverage for the CIDR helpers the privileged helper uses to decide whether a NETWORK route is
+// already installed correctly (#65).
+//
+// Why this matters more than it looks: `routeAlreadyCorrect` skips the kernel write when the route
+// already matches. For network routes it compares `route -n get -net <cidr>`'s `destination:` and
+// `mask:` against these two functions' output. If `netmaskString` is wrong, the comparison fails
+// forever (harmless churn) — but if `parse` accepts a non-canonical prefix and yields a DIFFERENT
+// value than the caller intended, the helper can conclude "already correct" about a route that is
+// not the one requested, and silently skip installing it. In VPN Only mode the routes in question
+// are the `0.0.0.0/1` + `128.0.0.0/1` catch-alls, so a wrong skip there is a traffic leak.
+
+import XCTest
+@testable import VPNBypassCore
+
+final class RouteCIDRTests: XCTestCase {
+
+    // MARK: - netmaskString
+
+    /// The two VPN Only catch-alls are /1 routes; `route` prints their mask as 128.0.0.0.
+    func testNetmaskForCatchAllHalfSpaces() {
+        XCTAssertEqual(RouteCIDR.netmaskString(prefixLength: 1), "128.0.0.0")
+    }
+
+    func testNetmaskForCommonPrefixes() {
+        XCTAssertEqual(RouteCIDR.netmaskString(prefixLength: 8), "255.0.0.0")
+        XCTAssertEqual(RouteCIDR.netmaskString(prefixLength: 16), "255.255.0.0")
+        XCTAssertEqual(RouteCIDR.netmaskString(prefixLength: 24), "255.255.255.0")
+        XCTAssertEqual(RouteCIDR.netmaskString(prefixLength: 32), "255.255.255.255")
+    }
+
+    /// `route(8)` prints a /0 as "default", not "0.0.0.0" — comparing against the wrong spelling
+    /// would never match.
+    func testNetmaskForZeroPrefixIsDefault() {
+        XCTAssertEqual(RouteCIDR.netmaskString(prefixLength: 0), "default")
+    }
+
+    func testNetmaskRejectsOutOfRangePrefix() {
+        XCTAssertEqual(RouteCIDR.netmaskString(prefixLength: 33), "default")
+        XCTAssertEqual(RouteCIDR.netmaskString(prefixLength: -1), "default")
+    }
+
+    // MARK: - parse
+
+    func testParseSplitsNetworkAndPrefix() {
+        let parsed = RouteCIDR.parse("10.0.0.0/8")
+        XCTAssertEqual(parsed?.network, "10.0.0.0")
+        XCTAssertEqual(parsed?.prefixLength, 8)
+    }
+
+    func testParseHandlesTheCatchAlls() {
+        XCTAssertEqual(RouteCIDR.parse("0.0.0.0/1")?.prefixLength, 1)
+        XCTAssertEqual(RouteCIDR.parse("128.0.0.0/1")?.network, "128.0.0.0")
+    }
+
+    /// A non-canonical prefix must be REJECTED rather than silently normalised. "/08" parsing as 8
+    /// would make the helper compare against a mask the caller never asked for, and a match there
+    /// means skipping a write that was needed.
+    func testParseRejectsNonCanonicalPrefix() {
+        XCTAssertNil(RouteCIDR.parse("10.0.0.0/08"))
+        XCTAssertNil(RouteCIDR.parse("10.0.0.0/+8"))
+        XCTAssertNil(RouteCIDR.parse("10.0.0.0/ 8"))
+    }
+
+    func testParseRejectsOutOfRangePrefix() {
+        XCTAssertNil(RouteCIDR.parse("10.0.0.0/33"))
+        XCTAssertNil(RouteCIDR.parse("10.0.0.0/-1"))
+    }
+
+    func testParseRejectsMalformedNetwork() {
+        XCTAssertNil(RouteCIDR.parse("10.0.0/8"))          // three octets
+        XCTAssertNil(RouteCIDR.parse("10.0.0.256/8"))      // octet out of range
+        XCTAssertNil(RouteCIDR.parse("10.0.0.01/8"))       // non-canonical octet
+        XCTAssertNil(RouteCIDR.parse("notanip/8"))
+    }
+
+    func testParseRejectsMissingOrExtraPrefix() {
+        XCTAssertNil(RouteCIDR.parse("10.0.0.0"))          // a host, not a CIDR
+        XCTAssertNil(RouteCIDR.parse("10.0.0.0/8/8"))
+        XCTAssertNil(RouteCIDR.parse("10.0.0.0/"))
+    }
+
+    /// End-to-end shape of what the helper actually compares: for each catch-all, the pair
+    /// (network, mask) must equal what `route -n get -net` reports for an installed route.
+    func testCatchAllsProduceTheExactPairRouteWouldPrint() {
+        guard let low = RouteCIDR.parse("0.0.0.0/1"), let high = RouteCIDR.parse("128.0.0.0/1") else {
+            return XCTFail("catch-alls must parse")
+        }
+        XCTAssertEqual(low.network, "0.0.0.0")
+        XCTAssertEqual(RouteCIDR.netmaskString(prefixLength: low.prefixLength), "128.0.0.0")
+        XCTAssertEqual(high.network, "128.0.0.0")
+        XCTAssertEqual(RouteCIDR.netmaskString(prefixLength: high.prefixLength), "128.0.0.0")
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to VPN Bypass will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.9] - 2026-08-07
+
+### Fixed
+- **A route could be silently skipped and never installed.** The "is this route already correct?" check added in 3.1.8 didn't look at route flags, so a short-lived route the kernel creates automatically (which inherits its gateway from the default route) could be mistaken for one of ours. The app then recorded the route as applied, wrote nothing, and the temporary route later expired — leaving that destination going somewhere else entirely, with no error anywhere. The check is now much stricter about what counts as a match.
+- **VPN Only still rewrote its catch-all routes on every pass.** The 3.1.8 fix skipped network routes, which is exactly what VPN Only's two catch-alls are — so the churn that destabilises other VPN clients was never fixed in the mode where it matters most.
+- **VPN Only briefly sent protected traffic in the clear on every apply.** The catch-all routes were installed *before* the routes for your listed domains, so for the duration of an apply — hundreds of routes, one at a time — the very destinations you asked to protect fell back to your normal connection. Catch-alls are now installed last, mirroring teardown, which already removes them first.
+- **VPN Only left all traffic outside the tunnel when GlobalProtect appeared.** The app refuses to enable VPN Only under GlobalProtect, but it only refused to *add* the catch-alls — any already installed stayed, silently routing everything around the tunnel while the app looked healthy. They are now removed, and you're told why.
+- **Upgrading left every route behind.** Quitting the app cleans up its routes, but the Homebrew upgrade path stops the app with a signal that skipped that cleanup entirely — so an upgrade stranded the whole route set with nothing able to remove it afterwards. Routes are now cleaned up on that path too.
+- **A stuck `route` command could freeze all routing changes.** Since 3.1.7 route operations run one at a time, so a single hung command blocked every later change for as long as the helper stayed running. Commands are now bounded and cancelled if they overrun.
+- **Failing to route anything at all is no longer silent.** The one case guaranteed to produce no notification was total failure. You now get told when no routes could be applied — no gateway, no VPN for VPN Only, or the helper not being ready.
+- **Corrected the mode descriptions in the README and roadmap**, which had VPN Only backwards — they described it as sending everything *through* the VPN except your list, when it does the opposite.
+
+### Changed
+- Helper version 1.10.0 → 1.11.0 (one admin prompt on first launch after upgrading).
+- The privileged helper now rejects a `/0` route, matching the app.
+- Tests no longer read or write the real DNS cache file.
+
 ## [3.1.8] - 2026-08-06
 
 ### Fixed


### PR DESCRIPTION
Second review pass over 3.1.7/3.1.8. Full detail in the commit message and CHANGELOG 3.1.9.

**Leak-critical**
- Catch-alls now installed **last** — installing them first sent the very destinations the user asked to protect out in the clear for the duration of every apply.
- The GlobalProtect refusal now **tears down** catch-alls already installed instead of only declining to add more (they were left routing everything around the tunnel, permanently).
- **SIGTERM** now runs the same teardown as Quit — the Homebrew upgrade path stranded the entire route set untracked.

**Helper**
- `routeAlreadyCorrect` now parses flags: a kernel-**cloned** route inheriting the default gateway matched as "already correct" in Bypass mode, so the real route was silently never installed.
- Network routes no longer excluded from that check (VPN Only rewrote both catch-alls every apply).
- Route subprocesses are now time-bounded — one wedged child blocked the whole serial mutation queue for the life of the daemon.
- Rejects `/0`, matching the app.

Also: total-failure notification, NotificationManager no-ops under XCTest, dnsCacheURL no longer touches the real cache from tests, XPC budget corrected.

CI verified green on 78ab1d66 by dispatch — this repo's `pull_request` trigger is broken (see below), so the PR rollup will not show it.

867 tests, 0 failures; universal helper builds. helperVersion 1.10.0 → 1.11.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route matching for network destinations and rejected unsafe or invalid routes.
  * VPN Only mode now applies catch-all routes in the correct order and cleans up conflicting routes.
  * Route commands now time out safely instead of becoming stuck.
  * Added notifications when route enforcement fails.
  * Improved cleanup during application termination and isolated test DNS cache access.

* **Documentation**
  * Clarified routing mode behavior and updated release documentation.

* **Maintenance**
  * Updated the privileged helper to version 1.11.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->