### PR TITLE
fix: keep still-valid routes across a VPN reconnect (#65, #67)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # VPN Bypass - Product Roadmap
 
-## Current State (v3.1.9)
+## Current State (v3.1.10)
 
 Three routing modes ship today: **Bypass** (everything uses the VPN except the listed domains/services,
 which skip it), **VPN Only** (the inverse — everything goes direct except the listed items, which are

--- a/Sources/VPNBypassCore/MenuBarViews.swift
+++ b/Sources/VPNBypassCore/MenuBarViews.swift
@@ -30,15 +30,32 @@ struct MenuBarLabel: View {
         return Self.iconDefault
     }
 
+    /// States the routing CONTRACT, not just a count.
+    ///
+    /// Bypass and VPN Only are near-opposites — one sends everything through the VPN except your
+    /// list, the other sends everything direct except your list — and the menu bar rendered them
+    /// identically: same glyph, same number. A user who changed mode a week ago had no ambient way
+    /// to tell which one was running, which is precisely the confusion behind a user reporting that
+    /// their public IP was their real one "while the app was on".
     private var iconAccessibilityLabel: String {
         if helperManager.helperState.isFailed {
-            return "VPN Bypass: helper error"
-        } else if routeManager.isVPNConnected && !routeManager.activeRoutes.isEmpty {
-            return "VPN Bypass: \(routeManager.uniqueRouteCount) active routes"
-        } else if routeManager.isVPNConnected {
-            return "VPN Bypass: VPN connected, no routes"
+            return String(localized: "VPN Bypass: helper error, nothing is being routed")
         }
-        return "VPN Bypass: inactive"
+        guard routeManager.isVPNConnected else {
+            return String(localized: "VPN Bypass: no VPN detected, nothing is being routed")
+        }
+        let count = routeManager.uniqueRouteCount
+        guard !routeManager.activeRoutes.isEmpty else {
+            return String(localized: "VPN Bypass: VPN connected but no routes are being enforced")
+        }
+        switch routeManager.config.routingMode {
+        case .vpnOnly:
+            return String(localized: "VPN Bypass — VPN Only: \(count) destinations use the VPN, everything else is direct")
+        case .custom:
+            return String(localized: "VPN Bypass — Custom: \(count) destinations routed by your rules")
+        default:
+            return String(localized: "VPN Bypass — Bypass: \(count) destinations skip the VPN, everything else is tunnelled")
+        }
     }
 
     private var menuBarIcon: some View {

--- a/Sources/VPNBypassCore/RerouteDecider.swift
+++ b/Sources/VPNBypassCore/RerouteDecider.swift
@@ -45,6 +45,14 @@ enum RerouteDecider {
     ///   installing routes (a local gateway present, the privileged helper ready).
     /// - If needed but any precondition is blocked → `.latch` (defer, don't drop).
     /// - If not needed → `.none` (blockers are irrelevant when there's nothing to do).
+    /// - Parameter gatewayChanged: the VPN's gateway address changed while the interface name did
+    ///   NOT. A tunnel that renegotiates keeps `utunN` but can come back on a different next-hop,
+    ///   and every other signal here is blind to that: `interfaceChanged` compares names, and the
+    ///   DNS refresh only schedules work for destinations it does not already track, so an
+    ///   already-installed route is never revisited. The route then stays pinned to a gateway that
+    ///   no longer exists — in VPN Only the listed destinations blackhole (ARP to a dead next-hop)
+    ///   rather than leak, so it fails safe, but it fails silently and does not self-heal.
+    ///   Defaulted so existing callers and the decision-table tests keep their meaning.
     static func decide(
         interfaceChanged: Bool,
         tailscaleChanged: Bool,
@@ -52,9 +60,10 @@ enum RerouteDecider {
         isLoading: Bool,
         isApplyingRoutes: Bool,
         cooldownActive: Bool,
-        hasGateway: Bool
+        hasGateway: Bool,
+        gatewayChanged: Bool = false
     ) -> RerouteAction {
-        let needed = interfaceChanged || tailscaleChanged || pending
+        let needed = interfaceChanged || tailscaleChanged || pending || gatewayChanged
         guard needed else { return .none }
 
         let canRunNow = !isLoading && !isApplyingRoutes && !cooldownActive && hasGateway

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -378,6 +378,9 @@ final class RouteManager: ObservableObject {
     func checkVPNStatus() async {
         let wasVPNConnected = isVPNConnected
         let oldInterface = vpnInterface
+        // Captured BEFORE re-detection below overwrites it, so a same-interface gateway change is
+        // detectable at all — see `gatewayChanged` further down.
+        let oldVPNGateway = vpnGateway
         let oldTailscaleFingerprint = lastTailscaleSelfFingerprint
 
         // Detect current network first
@@ -467,9 +470,20 @@ final class RouteManager: ObservableObject {
             // Reason for logging; nil when this pass only drains an existing latch
             // (interfaceChanged / tailscaleChanged already false), in which case the
             // reason captured when the latch was set is reused.
+            // Same interface, different next-hop. A tunnel that renegotiates keeps utunN but can
+            // return on a new gateway; nothing else notices, because interfaceChanged compares
+            // names and the DNS refresh only schedules destinations it does not already track. The
+            // routes would stay pinned to a gateway that no longer exists.
+            let gatewayChanged = isVPNConnected && wasVPNConnected
+                && interface == oldInterface
+                && oldVPNGateway != nil && vpnGateway != nil
+                && oldVPNGateway != vpnGateway
+
             let rerouteReason: String? = interfaceChanged
                 ? "VPN interface changed: \(oldInterface ?? "?") → \(interface ?? "?")"
-                : (tailscaleChanged ? "Tailscale active account changed, refreshing routes" : nil)
+                : (gatewayChanged
+                    ? "VPN gateway changed on \(interface ?? "?"): \(oldVPNGateway ?? "?") → \(vpnGateway ?? "?")"
+                    : (tailscaleChanged ? "Tailscale active account changed, refreshing routes" : nil))
 
             switch RerouteDecider.decide(
                 interfaceChanged: interfaceChanged,
@@ -478,7 +492,8 @@ final class RouteManager: ObservableObject {
                 isLoading: isLoading,
                 isApplyingRoutes: isApplyingRoutes,
                 cooldownActive: rerouteCooldownActive(),
-                hasGateway: canApplyRoutes
+                hasGateway: canApplyRoutes,
+                gatewayChanged: gatewayChanged
             ) {
             case .reroute:
                 if let rerouteReason { pendingRerouteReason = rerouteReason }

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -519,8 +519,36 @@ final class RouteManager: ObservableObject {
             pendingRerouteReason = nil
             rerouteRetryTask?.cancel()
             rerouteRetryTask = nil
-            // Remove kernel routes before clearing in-memory state
-            await removeAllRoutes()
+            // Remove only what actually went stale.
+            //
+            // In Bypass mode every route egresses via the LOCAL gateway, so a VPN disconnect leaves
+            // them all still correct — those destinations were already going direct and continue to.
+            // Tearing the whole set down and rebuilding it on reconnect was the dominant source of
+            // churn once a tunnel started flapping: 15 disconnects produced 8 full 342-route
+            // rebuilds in one day here, and each rebuild fires hundreds of kernel route-change
+            // events that the VPN client then reacts to — feeding the very instability that caused
+            // the disconnect. Keeping the still-valid routes means a reconnect finds them already
+            // correct and costs zero mutations.
+            //
+            // VPN Only keeps the full teardown: its catch-alls are leak-critical and its listed
+            // destinations point at a gateway that is now gone, so there is nothing worth keeping.
+            if config.routingMode == .bypass {
+                let stale = Self.vpnBoundDestinations(
+                    activeRoutes: activeRoutes,
+                    localGateway: localGateway,
+                    catchAlls: RouteCompiler.catchAllDestinations
+                )
+                if stale.isEmpty {
+                    log(.info, "VPN gone; \(activeRoutes.count) bypass route(s) still egress the local gateway — keeping them")
+                } else {
+                    log(.info, "VPN gone; removing \(stale.count) VPN-bound route(s), keeping \(activeRoutes.count - stale.count) local-gateway route(s)")
+                    let result = await removeRoutesBatchVia(stale)
+                    let removed = Set(stale).subtracting(result.failedDestinations)
+                    activeRoutes.removeAll { removed.contains($0.destination) }
+                }
+            } else {
+                await removeAllRoutes()
+            }
             routeVerificationResults.removeAll()
             lastTailscaleSelfFingerprint = nil
             vpnGateway = nil
@@ -1055,6 +1083,32 @@ final class RouteManager: ObservableObject {
     /// route monitor and tears the tunnel down (the original incident), so EVERY
     /// route-applying path must refuse it. Returns true (and logs) when the apply
     /// should be skipped.
+    /// Destinations whose route becomes STALE when the VPN goes away: anything egressing via the
+    /// VPN gateway or bound to a tunnel interface, plus the VPN-Only catch-alls.
+    ///
+    /// Pure so it can be tested without a helper, a kernel, or a live VPN.
+    ///
+    /// The point of the split: in Bypass mode every route egresses via the LOCAL gateway, so a VPN
+    /// disconnect leaves them all perfectly valid — those domains were already going direct, and
+    /// they continue to. Tearing the whole set down and rebuilding it on reconnect was pure churn,
+    /// and with a tunnel that reconnects often it dominated everything: one machine logged 15
+    /// disconnects and 8 full 342-route rebuilds in a day, each rebuild firing hundreds of kernel
+    /// route-change events that the VPN client itself then reacts to.
+    nonisolated static func vpnBoundDestinations(
+        activeRoutes: [ActiveRoute],
+        localGateway: String?,
+        catchAlls: Set<String>
+    ) -> [String] {
+        activeRoutes.compactMap { route in
+            if catchAlls.contains(route.destination) { return route.destination }
+            // Interface-scoped routes name a tunnel that is going away.
+            if route.gateway.hasPrefix("iface:") { return route.destination }
+            // Anything not egressing via the local gateway is VPN-bound.
+            if let local = localGateway, route.gateway == local { return nil }
+            return route.destination
+        }
+    }
+
     /// Catch-alls this app currently believes it owns. Used by the GlobalProtect refusal so it can
     /// remove what is already installed rather than only declining to add more.
     private var installedCatchAllDestinations: [String] {

--- a/Sources/VPNBypassCore/VPNBypassApp.swift
+++ b/Sources/VPNBypassCore/VPNBypassApp.swift
@@ -168,11 +168,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         networkDebounceWorkItem?.cancel()
         RouteManager.shared.stopDNSRefreshTimer()
 
-        // Clean up routes and hosts file on quit, then allow termination
+        // Clean up routes and hosts file on quit, then allow termination.
+        //
+        // The safety deadline has to scale with the work, not sit at a flat 8s. Teardown removes
+        // one route per `/sbin/route` subprocess, and a normal config here installs 300+; at the
+        // measured per-route cost that ran well past 8s, so the app replied "go ahead" and was
+        // killed mid-teardown. Everything past the cut-off stayed installed — and because route
+        // ownership lives only in this process's memory, the next launch started with an empty
+        // model and could never remove it. In VPN Only the survivors can include the catch-alls,
+        // whose own batch budget (10.5s) already exceeded the old cap on its own.
+        //
+        // Catch-alls are torn down first (see removeAllRoutes), so the most leak-relevant work is
+        // done early; this budget is about not abandoning the remainder.
+        let trackedRouteCount = RouteManager.shared.activeRoutes.count
+        let quitDeadline = min(60.0, 8.0 + Double(trackedRouteCount) * 0.15)
         var didReply = false
-        DispatchQueue.main.asyncAfter(deadline: .now() + 8) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + quitDeadline) {
             guard !didReply else { return }
             didReply = true
+            RouteManager.shared.log(.warning, "Quit teardown exceeded \(Int(quitDeadline))s — some routes may remain installed")
             NSApp.reply(toApplicationShouldTerminate: true)
         }
         Task { @MainActor in

--- a/Tests/VPNBypassTests/RerouteDeciderTests.swift
+++ b/Tests/VPNBypassTests/RerouteDeciderTests.swift
@@ -6,7 +6,7 @@
 // never re-fire — a silent, persistent VPN leak. These tests pin the three-way
 // decision that now LATCHES a blocked re-route (via `pending`) and drains it later,
 // so a needed re-route is never lost. Each expected action is hand-computed from:
-//   needed    = interfaceChanged || tailscaleChanged || pending
+//   needed    = interfaceChanged || tailscaleChanged || pending || gatewayChanged
 //   canRunNow = !isLoading && !isApplyingRoutes && !cooldownActive && hasGateway
 //   result    = !needed ? .none : (canRunNow ? .reroute : .latch)
 
@@ -149,6 +149,38 @@ final class RerouteDeciderTests: XCTestCase {
             interfaceChanged: true, tailscaleChanged: false, pending: false,
             isLoading: true, isApplyingRoutes: true, cooldownActive: true, hasGateway: false
         ), .latch)
+    }
+
+
+    // MARK: - Gateway changed on the SAME interface
+
+    /// A tunnel that renegotiates keeps `utunN` but can return on a different next-hop. Nothing
+    /// else in the app notices: `interfaceChanged` compares names, and the DNS refresh only
+    /// schedules destinations it does not already track, so an installed route is never revisited.
+    /// The routes would stay pinned to a gateway that no longer exists — in VPN Only the listed
+    /// destinations blackhole rather than leak, so it fails safe, but silently and without healing.
+    func testGatewayChangedAloneNeedsAReroute() {
+        XCTAssertEqual(RerouteDecider.decide(
+            interfaceChanged: false, tailscaleChanged: false, pending: false,
+            isLoading: false, isApplyingRoutes: false, cooldownActive: false, hasGateway: true,
+            gatewayChanged: true
+        ), .reroute)
+    }
+
+    func testGatewayChangedLatchesWhenBlocked() {
+        XCTAssertEqual(RerouteDecider.decide(
+            interfaceChanged: false, tailscaleChanged: false, pending: false,
+            isLoading: false, isApplyingRoutes: true, cooldownActive: false, hasGateway: true,
+            gatewayChanged: true
+        ), .latch)
+    }
+
+    /// Default value keeps every pre-existing decision-table case meaning exactly what it did.
+    func testGatewayChangedDefaultsToFalse() {
+        XCTAssertEqual(RerouteDecider.decide(
+            interfaceChanged: false, tailscaleChanged: false, pending: false,
+            isLoading: false, isApplyingRoutes: false, cooldownActive: false, hasGateway: true
+        ), .none)
     }
 
     // MARK: - Premature-commit invariant

--- a/Tests/VPNBypassTests/VPNBoundRouteTests.swift
+++ b/Tests/VPNBypassTests/VPNBoundRouteTests.swift
@@ -1,0 +1,83 @@
+// VPNBoundRouteTests.swift
+// Coverage for which routes actually go stale when the VPN disconnects.
+//
+// Why this exists: the disconnect handler used to tear down EVERY route and the reconnect then
+// rebuilt them all. With a tunnel that flaps, that dominated everything — one machine logged 15
+// disconnect events and 8 full 342-route rebuilds in a single day, and every rebuild fires hundreds
+// of kernel route-change events that the VPN client itself reacts to, feeding the instability that
+// caused the disconnect in the first place.
+//
+// The distinction that fixes it: in Bypass mode every route egresses via the LOCAL gateway, so a
+// VPN disconnect leaves them correct — those destinations were already going direct. Only routes
+// bound to the VPN (its gateway, or a tunnel interface) and the VPN-Only catch-alls actually go
+// stale. Getting this wrong in the permissive direction would leave a route pointing at a dead
+// gateway (blackhole); in the aggressive direction it is merely the old churn.
+
+import XCTest
+@testable import VPNBypassCore
+
+final class VPNBoundRouteTests: XCTestCase {
+
+    private let local = "192.168.1.1"
+    private let vpn = "10.10.0.1"
+    private let catchAlls = RouteCompiler.catchAllDestinations
+
+    private func route(_ dest: String, _ gw: String, _ source: String = "s") -> RouteManager.ActiveRoute {
+        RouteManager.ActiveRoute(destination: dest, gateway: gw, source: source, timestamp: Date())
+    }
+
+    private func stale(_ routes: [RouteManager.ActiveRoute], localGateway: String? = "192.168.1.1") -> [String] {
+        RouteManager.vpnBoundDestinations(activeRoutes: routes, localGateway: localGateway, catchAlls: catchAlls)
+    }
+
+    /// The Bypass case, and the whole point of the change: nothing is stale, so a disconnect costs
+    /// zero kernel mutations and the reconnect finds every route already correct.
+    func testBypassRoutesViaLocalGatewayAreNotStale() {
+        let routes = [route("1.1.1.1", local), route("2.2.2.2", local), route("10.0.0.0/8", local)]
+        XCTAssertTrue(stale(routes).isEmpty,
+            "routes egressing the local gateway stay valid when the VPN goes away — removing them is pure churn")
+    }
+
+    /// Routes pointing at the VPN's gateway are dead the moment the tunnel drops; leaving them
+    /// installed would blackhole those destinations.
+    func testRoutesViaVPNGatewayAreStale() {
+        let routes = [route("3.3.3.3", vpn), route("4.4.4.4", local)]
+        XCTAssertEqual(stale(routes), ["3.3.3.3"])
+    }
+
+    /// Interface-scoped routes name a tunnel that is going away (the `iface:` convention used for
+    /// VPNs that publish a link-only default route, e.g. Cisco Secure Client).
+    func testInterfaceBoundRoutesAreStale() {
+        let routes = [route("5.5.5.5", "iface:utun4"), route("6.6.6.6", local)]
+        XCTAssertEqual(stale(routes), ["5.5.5.5"])
+    }
+
+    /// VPN-Only catch-alls are always torn down, even though they egress the LOCAL gateway and so
+    /// would otherwise look "still valid" by the gateway test alone.
+    func testCatchAllsAreAlwaysStaleEvenViaLocalGateway() {
+        let routes = [route("0.0.0.0/1", local, "VPN Only catch-all"),
+                      route("128.0.0.0/1", local, "VPN Only catch-all"),
+                      route("7.7.7.7", local)]
+        XCTAssertEqual(Set(stale(routes)), ["0.0.0.0/1", "128.0.0.0/1"])
+    }
+
+    /// With no known local gateway we cannot prove any route is still valid, so everything is
+    /// treated as stale. Fails toward removing (churn) rather than toward leaving a dead route.
+    func testUnknownLocalGatewayTreatsEverythingAsStale() {
+        let routes = [route("8.8.8.8", local), route("9.9.9.9", vpn)]
+        XCTAssertEqual(Set(stale(routes, localGateway: String?.none)), ["8.8.8.8", "9.9.9.9"])
+    }
+
+    func testEmptyRouteSetHasNothingStale() {
+        XCTAssertTrue(stale([]).isEmpty)
+    }
+
+    /// Mixed real-world shape: a Bypass set plus one leftover VPN-bound route.
+    func testMixedSetRemovesOnlyTheVPNBoundOne() {
+        let routes = [route("1.1.1.1", local), route("2.2.2.2", local),
+                      route("3.3.3.3", vpn), route("4.4.4.4", local)]
+        let result = stale(routes)
+        XCTAssertEqual(result, ["3.3.3.3"])
+        XCTAssertEqual(routes.count - result.count, 3, "the three local-gateway routes must be kept")
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to VPN Bypass will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.10] - 2026-08-07
+
+### Fixed
+- **A VPN reconnect no longer rebuilds every route.** When the VPN dropped, the app removed *all* of its routes and re-added them once it came back. With a tunnel that reconnects often this dominated everything — one machine logged 15 disconnects and 8 full 342-route rebuilds in a single day, and each rebuild fires hundreds of routing-table changes that the VPN client itself then reacts to, feeding the very instability that caused the disconnect. In Bypass mode your routes go through your normal connection, so they stay perfectly valid while the VPN is away; they are now kept, and a reconnect finds them already correct and changes nothing. VPN Only still tears down fully, because its routes genuinely do point at a gateway that has gone.
+- **A VPN that reconnects on a new gateway is now noticed.** If the tunnel came back on the same interface but a different next-hop, nothing detected it and the routes stayed pinned to a gateway that no longer existed — those destinations silently stopped working until the next restart.
+- **Quitting no longer abandons routes half-removed.** The shutdown cleanup was given a flat 8 seconds regardless of how many routes existed; with a few hundred it was cut off partway through, and whatever remained could never be cleaned up afterwards. The time allowed now scales with the number of routes.
+
+### Changed
+- The menu bar now says which mode is active and what it means, instead of only a route count. Bypass and VPN Only are near-opposites and used to look identical.
+
 ## [3.1.9] - 2026-08-07
 
 ### Fixed


### PR DESCRIPTION
3.1.9 fixed the steady-state churn (measured: 0 mutations, 0 helper route forks with the VPN connected). But a **flapping** tunnel still cost a full teardown-and-rebuild per cycle — 15 disconnects produced 8 full 342-route rebuilds in one day on a live machine, each firing hundreds of kernel route-change events that GlobalProtect's monitor reacts to, feeding the instability that caused the disconnect.

**Cause**: the disconnect handler tore down *every* route unconditionally. But in Bypass mode every route egresses via the **local** gateway, so a VPN disconnect leaves them all still correct — those destinations were already going direct and continue to.

**Fix**: `vpnBoundDestinations` (pure, 7 tests) names exactly what goes stale — routes via the VPN gateway, interface-scoped routes naming a departing tunnel, and the VPN-Only catch-alls. Bypass removes only those (usually none), so a reconnect finds routes already correct and costs zero mutations. VPN Only keeps the full teardown: its catch-alls are leak-critical and its destinations point at a gateway that is genuinely gone.

Fails safe: unknown local gateway ⇒ everything treated as stale (churn) rather than leaving a dead next-hop (blackhole).

Also in this PR: re-route on `gatewayChanged` (a tunnel returning on a new next-hop left routes pinned to a dead gateway, silently), a quit deadline that scales with route count (flat 8s was cutting teardown off partway), and a menu bar that states the active mode (Bypass and VPN Only rendered identically).

App-only — helper stays 1.11.0, so no admin prompt. CI verified green on e1440b9 by dispatch (this repo's pull_request trigger is broken). 877 tests, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * VPN gateway changes now trigger route updates, even when the VPN interface remains unchanged.
  * Bypass mode preserves valid local-gateway routes when the VPN disconnects.
  * Shutdown cleanup now allows more time when many routes are active.
  * Menu bar accessibility labels now clearly describe VPN and routing status.

* **Documentation**
  * Updated the roadmap and changelog for version 3.1.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->