### PR TITLE
fix: never claim or touch another network service's tunnel (#65)

### DIFF
--- a/Helper/HelperTool.swift
+++ b/Helper/HelperTool.swift
@@ -593,6 +593,20 @@ class HelperTool: NSObject, HelperProtocol {
     }
     
     private func isValidDestination(_ string: String) -> Bool {
+        // Refuse destinations owned by other networking software on this machine — Tailscale's
+        // tailnet range and MagicDNS — plus kernel-reserved space. Enforced HERE, at the privileged
+        // boundary, so the root daemon is the strictest layer rather than the most permissive; the
+        // same reasoning that makes it reject /0.
+        //
+        // Without this, a VPN Only entry of exactly 100.64.0.0/10 reached `route change -net`,
+        // matched on destination, and silently repointed Tailscale's own route into the corporate
+        // tunnel — and teardown would then delete it outright. Mesh networking would break with
+        // nothing indicating this app was responsible.
+        if ProtectedDestinations.isProtected(string) {
+            helperLog.error("refusing protected destination \(string, privacy: .public) — it belongs to another network service")
+            return false
+        }
+
         // Can be IP or CIDR notation
         if string.contains("/") {
             let parts = string.components(separatedBy: "/")

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # VPN Bypass - Product Roadmap
 
-## Current State (v3.1.11)
+## Current State (v3.1.12)
 
 Three routing modes ship today: **Bypass** (everything uses the VPN except the listed domains/services,
 which skip it), **VPN Only** (the inverse — everything goes direct except the listed items, which are

--- a/Sources/VPNBypassCore/HelperProtocol.swift
+++ b/Sources/VPNBypassCore/HelperProtocol.swift
@@ -240,3 +240,49 @@ public enum NetworkServiceOrder {
         return services
     }
 }
+
+/// Destinations this app must NEVER install, change, or delete, because they belong to other
+/// networking software sharing the machine — or to the kernel itself.
+///
+/// Enforced at the privileged boundary (the root daemon), deliberately: the helper must be the
+/// strictest layer, never the most permissive. Whatever the app asks for, these are refused.
+///
+/// The motivating case is Tailscale. It runs alongside this app in mesh mode, owns `100.64.0.0/10`
+/// and answers DNS on `100.100.100.100`. Nothing previously stopped a route for either from being
+/// written: a user CIDR of exactly `100.64.0.0/10` in VPN Only would reach `route change -net`,
+/// match on destination, and silently repoint Tailscale's own route into the corporate tunnel —
+/// and teardown would then delete it outright. Mesh networking would break with no indication that
+/// this app was responsible.
+///
+/// Note this is the UNCONDITIONAL list only. Individual host routes that merely fall inside CGNAT
+/// are a policy question for the app layer, which knows whether Tailscale is actually running;
+/// blocking them here would break legitimate Zscaler/WARP setups that share the same range.
+public enum ProtectedDestinations {
+    /// Tailscale's CGNAT range. A destination equal to it, or covering it, is refused.
+    public static let tailscaleCGNAT = (network: "100.64.0.0", prefix: 10)
+    /// Tailscale MagicDNS.
+    public static let magicDNS = "100.100.100.100"
+
+    public static func isProtected(_ destination: String) -> Bool {
+        let d = destination.trimmingCharacters(in: .whitespaces)
+
+        // MagicDNS, in host or /32 form.
+        if d == magicDNS || d == "\(magicDNS)/32" { return true }
+
+        if let (network, prefix) = RouteCIDR.parse(d) {
+            // The tailnet range itself, or any prefix that COVERS it — a shorter prefix on the same
+            // network wins longest-prefix match against Tailscale's own route just as surely.
+            if network == tailscaleCGNAT.network && prefix <= tailscaleCGNAT.prefix { return true }
+            // Kernel-reserved space nothing here should ever route.
+            if network == "127.0.0.0" { return true }
+            if network == "169.254.0.0" { return true }
+            if network == "224.0.0.0" { return true }
+        }
+
+        // Host forms of the same reserved space.
+        if d.hasPrefix("127.") || d.hasPrefix("169.254.") { return true }
+        if d == "255.255.255.255" { return true }
+
+        return false
+    }
+}

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -834,11 +834,33 @@ final class RouteManager: ObservableObject {
         // (Zscaler, WARP, etc.) so we accept it without requiring a process hint.
         // This fixes detection when VPN process names don't match known patterns (#18).
         if first == 100 && second >= 64 && second <= 127 {
-            if await isTailscaleIP(ip) {
+            // CGNAT (100.64/10) is shared ground: Tailscale, Zscaler and Cloudflare WARP all live
+            // here, so an address alone proves nothing and we have to ask Tailscale directly.
+            //
+            // FAIL CLOSED when that question cannot be answered. This used to collapse two very
+            // different outcomes into one: `isTailscaleIP` returns false both when the address is
+            // confirmed NOT Tailscale's and when the status query could not run at all (CLI absent,
+            // or the 3s subprocess timeout hit — and it is queried on every status pass with no
+            // memoisation, so load is exactly when it fails). Both fell through to "accept as
+            // corporate VPN", meaning a failed lookup silently promoted Tailscale's own tunnel to
+            // being treated as the corporate VPN — after which this app would re-route around a
+            // mesh network it has no business touching, and flip-flop between the two tunnels as
+            // the answer changed from poll to poll.
+            //
+            // Claiming another tool's tunnel is never the safe default. If we cannot prove a CGNAT
+            // address is not Tailscale's, we decline it.
+            switch await classifyCGNATAddress(ip) {
+            case .tailscale:
+                // Tailscale is only "the VPN" when it is actually carrying traffic as an exit node;
+                // in ordinary mesh mode it must be left entirely alone.
                 return await isTailscaleExitNodeActive()
+            case .notTailscale:
+                // Confirmed a different CGNAT VPN (Zscaler, WARP) — that one really is the tunnel.
+                return true
+            case .undetermined:
+                log(.warning, "Could not determine whether \(ip) belongs to Tailscale — not treating it as the VPN")
+                return false
             }
-            // Non-Tailscale CGNAT IP on a VPN interface → accept as corporate VPN
-            return true
         }
         
         // Corporate VPNs typically use private ranges
@@ -872,6 +894,29 @@ final class RouteManager: ObservableObject {
     }
     
     /// Check if this IP is the local Tailscale node's address
+    /// Whether a CGNAT (100.64/10) address belongs to Tailscale — keeping "could not tell" DISTINCT
+    /// from "confirmed it does not".
+    ///
+    /// That distinction is the entire point. Collapsing the two is what allowed a failed status
+    /// query to promote Tailscale's own tunnel to "corporate VPN" (see isCorporateVPNIP).
+    enum CGNATIdentity { case tailscale, notTailscale, undetermined }
+
+    private func classifyCGNATAddress(_ ip: String) async -> CGNATIdentity {
+        guard let json = await readTailscaleStatusJSON() else { return .undetermined }
+
+        if let selfStatus = json["Self"] as? [String: Any],
+           let selfIPs = selfStatus["TailscaleIPs"] as? [String],
+           selfIPs.contains(ip) {
+            return .tailscale
+        }
+        if let topLevelIPs = json["TailscaleIPs"] as? [String],
+           topLevelIPs.contains(ip) {
+            return .tailscale
+        }
+        // Tailscale answered, and does not claim this address.
+        return .notTailscale
+    }
+
     private func isTailscaleIP(_ ip: String) async -> Bool {
         guard let json = await readTailscaleStatusJSON() else {
             return false

--- a/Tests/VPNBypassTests/ProtectedDestinationsTests.swift
+++ b/Tests/VPNBypassTests/ProtectedDestinationsTests.swift
@@ -1,0 +1,72 @@
+// ProtectedDestinationsTests.swift
+// Coverage for the destinations VPN Bypass must never touch because they belong to other
+// networking software sharing the machine.
+//
+// The motivating case: Tailscale runs alongside this app in mesh mode, owns 100.64.0.0/10 and
+// answers DNS on 100.100.100.100. Nothing previously stopped a route for either being written — a
+// VPN Only entry of exactly 100.64.0.0/10 would reach `route change -net`, match on destination,
+// and silently repoint Tailscale's own route into the corporate tunnel; teardown would then delete
+// it outright. Mesh networking would break with nothing indicating this app was responsible.
+//
+// Enforced at the privileged boundary (the root daemon), so it holds regardless of what the app
+// asks for — the same reasoning that makes the helper reject /0.
+
+import XCTest
+@testable import VPNBypassCore
+
+final class ProtectedDestinationsTests: XCTestCase {
+
+    // MARK: - Tailscale
+
+    func testTailnetRangeItselfIsProtected() {
+        XCTAssertTrue(ProtectedDestinations.isProtected("100.64.0.0/10"))
+    }
+
+    /// A SHORTER prefix on the same network covers the tailnet and wins longest-prefix match
+    /// against Tailscale's own route just as surely, so it must be refused too.
+    func testPrefixesCoveringTheTailnetAreProtected() {
+        XCTAssertTrue(ProtectedDestinations.isProtected("100.64.0.0/8"))
+        XCTAssertTrue(ProtectedDestinations.isProtected("100.64.0.0/1"))
+    }
+
+    func testMagicDNSIsProtectedInBothForms() {
+        XCTAssertTrue(ProtectedDestinations.isProtected("100.100.100.100"))
+        XCTAssertTrue(ProtectedDestinations.isProtected("100.100.100.100/32"))
+    }
+
+    /// Deliberately NOT protected: an ordinary host inside CGNAT. That range is shared with Zscaler
+    /// and Cloudflare WARP, and the helper cannot know whether Tailscale is running — refusing all
+    /// of it here would break legitimate bypasses for those clients. Whether to route an individual
+    /// CGNAT host is a policy decision for the app layer, which does know.
+    func testOrdinaryCGNATHostIsNotBlanketProtected() {
+        XCTAssertFalse(ProtectedDestinations.isProtected("100.127.106.1"))
+        XCTAssertFalse(ProtectedDestinations.isProtected("100.64.1.5"))
+    }
+
+    // MARK: - Kernel-reserved space
+
+    func testLoopbackLinkLocalMulticastAndBroadcastAreProtected() {
+        XCTAssertTrue(ProtectedDestinations.isProtected("127.0.0.1"))
+        XCTAssertTrue(ProtectedDestinations.isProtected("127.0.0.0/8"))
+        XCTAssertTrue(ProtectedDestinations.isProtected("169.254.1.1"))
+        XCTAssertTrue(ProtectedDestinations.isProtected("169.254.0.0/16"))
+        XCTAssertTrue(ProtectedDestinations.isProtected("224.0.0.0/4"))
+        XCTAssertTrue(ProtectedDestinations.isProtected("255.255.255.255"))
+    }
+
+    // MARK: - Ordinary traffic must still be routable
+
+    /// The policy must not become a blanket refusal — normal bypass destinations still work.
+    func testOrdinaryDestinationsAreAllowed() {
+        for d in ["1.1.1.1", "8.8.8.8", "140.82.121.3", "10.0.0.0/8",
+                  "192.168.1.0/24", "172.16.0.0/12", "13.107.42.14"] {
+            XCTAssertFalse(ProtectedDestinations.isProtected(d), "\(d) must remain routable")
+        }
+    }
+
+    /// Whitespace must not be a bypass for the policy.
+    func testWhitespaceDoesNotEvadeThePolicy() {
+        XCTAssertTrue(ProtectedDestinations.isProtected("  100.64.0.0/10  "))
+        XCTAssertTrue(ProtectedDestinations.isProtected(" 100.100.100.100 "))
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to VPN Bypass will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.12] - 2026-08-07
+
+### Fixed
+- **VPN Bypass can no longer mistake Tailscale for your VPN.** To tell apart the different services that share the `100.64.x` address range (Tailscale, Zscaler, Cloudflare WARP), the app asks Tailscale directly. If that question couldn't be answered — the command missing, or timing out under load — the app treated the address as your corporate VPN and would start re-routing traffic around your Tailscale mesh. It now declines whenever it can't be sure, because claiming another tool's tunnel is never the safe assumption.
+- **The app will no longer touch routes belonging to other network software.** Nothing previously stopped it writing a route for Tailscale's own address range or its DNS server. Listing Tailscale's range in VPN Only mode would have silently redirected the whole tailnet into the corporate tunnel, and removing it later would have deleted Tailscale's route outright — breaking mesh networking with nothing to indicate this app was responsible. Those destinations, along with loopback, link-local, multicast and broadcast, are now refused outright by the privileged helper, so the refusal holds no matter what the app asks for.
+
 ## [3.1.11] - 2026-08-07
 
 ### Fixed


### PR DESCRIPTION
Two changes, one guarantee: VPN Bypass affects the corporate tunnel and nothing else on the machine. Motivated by a user running GlobalProtect, Tailscale (mesh), and this app simultaneously.

**1. Fail closed when Tailscale can't be identified.** `isCorporateVPNIP`'s CGNAT branch collapsed two different answers into one — `isTailscaleIP` returns false both when an address is *confirmed not* Tailscale's and when the status query *couldn't run at all* (CLI absent, or the 3s subprocess timeout hit; it's queried every status pass with no memoisation, so load is exactly when it fails). Both fell through to `return true` = "accept as corporate VPN", so a failed lookup silently promoted Tailscale's own tunnel to being the VPN. `classifyCGNATAddress` now distinguishes tailscale / notTailscale / **undetermined**, and undetermined declines.

**2. Refuse protected destinations at the privileged boundary.** Nothing stopped a route being written for Tailscale's tailnet range or MagicDNS. A VPN Only entry of exactly `100.64.0.0/10` reached `route change -net`, matched on destination, and would silently repoint Tailscale's own route into the corporate tunnel — teardown then deleting it outright. `ProtectedDestinations` refuses the tailnet range **and any prefix covering it**, MagicDNS, and kernel-reserved space. Enforced in the helper's `isValidDestination` so the root daemon is the strictest layer, never the most permissive — the same reasoning that makes it reject `/0`.

**Deliberately NOT protected**: ordinary hosts inside CGNAT. That range is shared with Zscaler and WARP, and the helper can't know whether Tailscale is running; refusing all of it would break legitimate bypasses for those clients.

**Honest limit**: the Tailscale CLI answered 12/12 when probed on the affected machine, so the fail-open branch is a closed hazard rather than a reproduced cause of the utun8/utun9 oscillation.

CI green on c026335 by dispatch. 897 tests, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved VPN detection to avoid misidentifying Tailscale connections as corporate VPNs when status checks fail.
  - Prevented route changes for protected destinations, including Tailscale, DNS, loopback, link-local, multicast, and broadcast addresses.
  - Added support for recognizing protected destinations in host and CIDR formats.

- **Documentation**
  - Updated the current version and changelog to 3.1.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->