### PR TITLE
fix: a gateway notation flip is not a gateway change (#65)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # VPN Bypass - Product Roadmap
 
-## Current State (v3.1.12)
+## Current State (v3.1.13)
 
 Three routing modes ship today: **Bypass** (everything uses the VPN except the listed domains/services,
 which skip it), **VPN Only** (the inverse — everything goes direct except the listed items, which are

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -474,10 +474,24 @@ final class RouteManager: ObservableObject {
             // return on a new gateway; nothing else notices, because interfaceChanged compares
             // names and the DNS refresh only schedules destinations it does not already track. The
             // routes would stay pinned to a gateway that no longer exists.
+            // Only a change of ADDRESS counts, never a change of NOTATION.
+            //
+            // detectVPNGateway returns the next-hop IP when it can read one and falls back to the
+            // `iface:<name>` form when it cannot — so the same unchanged tunnel is reported as
+            // "10.167.222.191" on one pass and "iface:utun9" on the next. Comparing those as
+            // strings makes that flip look like a real gateway change, and the re-route it triggers
+            // re-issues the ENTIRE route set: observed as `VPN gateway changed on utun9:
+            // 10.167.222.191 → iface:utun9` followed immediately by `Adding 317 routes`, roughly
+            // ten seconds after GlobalProtect reconnected — hundreds of route-change events fired
+            // straight into the tunnel monitor that had just come up, which tore it down again.
+            //
+            // Both forms are only ever produced for the SAME interface, and `interface ==
+            // oldInterface` is already required above, so when either side is the `iface:` fallback
+            // the two are by construction the same gateway. Requiring both to be real addresses
+            // means we act on a genuine next-hop change and ignore the notation flip.
             let gatewayChanged = isVPNConnected && wasVPNConnected
                 && interface == oldInterface
-                && oldVPNGateway != nil && vpnGateway != nil
-                && oldVPNGateway != vpnGateway
+                && Self.isRealGatewayChange(from: oldVPNGateway, to: vpnGateway)
 
             let rerouteReason: String? = interfaceChanged
                 ? "VPN interface changed: \(oldInterface ?? "?") → \(interface ?? "?")"
@@ -894,6 +908,25 @@ final class RouteManager: ObservableObject {
     }
     
     /// Check if this IP is the local Tailscale node's address
+    /// True only when the VPN's next-hop ADDRESS genuinely changed — never when its NOTATION did.
+    ///
+    /// Callers must already have established that the interface is unchanged.
+    ///
+    /// `detectVPNGateway` reports the next-hop IP when it can read one and falls back to the
+    /// `iface:<name>` form when it cannot, so an unchanged tunnel alternates between
+    /// "10.167.222.191" and "iface:utun9" from pass to pass. Treating that as a change triggers a
+    /// re-route that re-issues the entire route set — observed live as 317 route writes ten seconds
+    /// after GlobalProtect reconnected, which tore the freshly-established tunnel down again.
+    ///
+    /// Since both forms describe the same interface, and the caller has already required the
+    /// interface to be unchanged, either side being the fallback form means the gateway is by
+    /// construction the same. Only two real addresses can express a real change.
+    nonisolated static func isRealGatewayChange(from old: String?, to new: String?) -> Bool {
+        guard let old, let new else { return false }
+        guard !old.hasPrefix("iface:"), !new.hasPrefix("iface:") else { return false }
+        return old != new
+    }
+
     /// Whether a CGNAT (100.64/10) address belongs to Tailscale — keeping "could not tell" DISTINCT
     /// from "confirmed it does not".
     ///

--- a/Tests/VPNBypassTests/GatewayChangeTests.swift
+++ b/Tests/VPNBypassTests/GatewayChangeTests.swift
@@ -1,0 +1,46 @@
+// GatewayChangeTests.swift
+// Regression coverage: a change of NOTATION must never be mistaken for a change of gateway.
+//
+// `detectVPNGateway` reports the next-hop IP when it can read one and falls back to `iface:<name>`
+// when it cannot, so an unchanged tunnel alternates between the two forms from pass to pass.
+// Treating that as a real change fires a re-route that re-issues the ENTIRE route set. Observed
+// live: `VPN gateway changed on utun9: 10.167.222.191 → iface:utun9` followed immediately by
+// `Adding 317 routes` — roughly ten seconds after GlobalProtect reconnected. Those hundreds of
+// route-change events went straight into the tunnel monitor that had just come up, and tore it
+// down again.
+
+import XCTest
+@testable import VPNBypassCore
+
+final class GatewayChangeTests: XCTestCase {
+
+    /// The exact regression, in both directions.
+    func testNotationFlipIsNotAGatewayChange() {
+        XCTAssertFalse(RouteManager.isRealGatewayChange(from: "10.167.222.191", to: "iface:utun9"),
+                       "IP → iface form is the same gateway written differently, not a change")
+        XCTAssertFalse(RouteManager.isRealGatewayChange(from: "iface:utun9", to: "10.167.222.191"),
+                       "iface → IP form is the same gateway written differently, not a change")
+    }
+
+    /// A genuine next-hop change must still be acted on — the detector exists because a tunnel that
+    /// renegotiates onto a new gateway would otherwise leave routes pinned to a dead next-hop.
+    func testRealAddressChangeIsStillDetected() {
+        XCTAssertTrue(RouteManager.isRealGatewayChange(from: "10.167.222.191", to: "10.167.222.250"))
+    }
+
+    func testUnchangedAddressIsNotAChange() {
+        XCTAssertFalse(RouteManager.isRealGatewayChange(from: "10.167.222.191", to: "10.167.222.191"))
+    }
+
+    func testInterfaceFormToDifferentInterfaceFormIsNotActedOn() {
+        // The caller already requires the interface to be unchanged, so this cannot represent a
+        // real change; and neither side is an address we could compare meaningfully.
+        XCTAssertFalse(RouteManager.isRealGatewayChange(from: "iface:utun9", to: "iface:utun4"))
+    }
+
+    func testMissingEitherSideIsNotAChange() {
+        XCTAssertFalse(RouteManager.isRealGatewayChange(from: nil, to: "10.0.0.1"))
+        XCTAssertFalse(RouteManager.isRealGatewayChange(from: "10.0.0.1", to: nil))
+        XCTAssertFalse(RouteManager.isRealGatewayChange(from: nil, to: nil))
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to VPN Bypass will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.13] - 2026-08-07
+
+### Fixed
+- **A VPN reconnect no longer triggers a full route rebuild seconds later.** The app reads the VPN's gateway either as an address or, when it can't read one, as the interface name — two ways of writing the same thing. It was comparing them as text, so an unchanged tunnel looked like it had switched gateways, and the app responded by re-installing every route. Seen live: a "gateway changed" a few seconds after GlobalProtect reconnected, followed by 317 routes being written at once, which was enough to knock the freshly-established tunnel down again. Only a genuine change of address now counts.
+
 ## [3.1.12] - 2026-08-07
 
 ### Fixed


### PR DESCRIPTION
A VPN reconnect triggered a full route rebuild a few seconds later, which tore the freshly-established tunnel back down.

## Cause

`detectVPNGateway` reports the VPN's next-hop as an **address** when it can read one, and falls back to the **`iface:<name>`** form when it cannot. Those are two ways of writing the same thing. The `gatewayChanged` detector compared them as strings, so an unchanged tunnel alternating between forms read as a real gateway change — and the response to a real gateway change is to re-issue the entire route set.

Observed live:

```
11:51:16  VPN gateway changed on utun9: <addr> → iface:utun9
11:51:31  Adding 317 routes via batch operation...
```

Roughly ten seconds after GlobalProtect reconnected, several hundred route-change events went into the tunnel monitor that had just come up. That is exactly the feedback loop #65 is about, reintroduced by my own fix for a different bug in the same area.

## Fix

Extracted the predicate as the pure, testable `RouteManager.isRealGatewayChange(from:to:)`.

Both forms describe the same interface, and the caller already requires the interface to be unchanged — so either side being the fallback form means the gateway is *by construction* the same. Only two real addresses can express a real change.

## Why a test and not just the fix

This is the third change in this area to cause a regression, so the predicate is now pure and covered rather than inline: 5 tests, including both directions of the notation flip and a genuine address change (which must still be acted on, or a renegotiated tunnel leaves routes pinned to a dead next-hop).

`902 tests, 0 failures`.

Refs #65