### PR TITLE
fix: choose the VPN interface deliberately when two tunnels are up

### DIFF
--- a/Sources/VPNBypassCore/HelperProtocol.swift
+++ b/Sources/VPNBypassCore/HelperProtocol.swift
@@ -286,3 +286,98 @@ public enum ProtectedDestinations {
         return false
     }
 }
+
+// MARK: - VPN interface selection
+
+/// One tunnel considered as "the VPN", with everything the choice depends on already resolved.
+public struct VPNCandidate: Equatable, Sendable {
+    public let interface: String
+    public let isUp: Bool
+    public let isTunnel: Bool
+    /// The address looks like a corporate VPN address (see `isCorporateVPNIP`).
+    public let isCorporateAddress: Bool
+    /// This is Tailscale's own utun.
+    public let isTailscale: Bool
+
+    public init(interface: String, isUp: Bool, isTunnel: Bool,
+                isCorporateAddress: Bool, isTailscale: Bool) {
+        self.interface = interface
+        self.isUp = isUp
+        self.isTunnel = isTunnel
+        self.isCorporateAddress = isCorporateAddress
+        self.isTailscale = isTailscale
+    }
+}
+
+/// Chooses which tunnel is "the VPN" when several are up at once.
+///
+/// This has to be deliberate because more than one tunnel is the normal case, not the exception:
+/// a corporate client and Tailscale routinely run together, and a Mac can easily show nine utun
+/// interfaces. Selection used to be "first match in `ifconfig` order", which is neither
+/// deterministic nor related to which tunnel carries traffic — and since Tailscale's utun usually
+/// sorts BEFORE a corporate client's, Tailscale won that race whenever an exit node made it look
+/// like a VPN. The consequence in VPN Only mode is a leak: the catch-alls are installed to escape
+/// the tunnel the app selected, sending the OTHER tunnel's corporate traffic direct.
+public enum VPNInterfaceSelector {
+
+    public static func select(candidates: [VPNCandidate],
+                              defaultRouteInterface: String?,
+                              current: String?) -> String? {
+        // Tailscale is excluded outright. In mesh mode it is not a VPN at all, and as an exit node
+        // it has its own egress route type — it must never become the tunnel whose traffic the app
+        // reroutes, because doing so silently changes what a corporate VPN policy applies to.
+        let eligible = candidates.filter {
+            $0.isUp && $0.isTunnel && $0.isCorporateAddress && !$0.isTailscale
+        }
+        guard !eligible.isEmpty else { return nil }
+
+        // 1. Ground truth. The tunnel carrying the default route is the one actually moving
+        //    traffic; no heuristic beats observing it. A change here is a real change worth acting
+        //    on, so this deliberately outranks hysteresis.
+        if let defaultRouteInterface,
+           eligible.contains(where: { $0.interface == defaultRouteInterface }) {
+            return defaultRouteInterface
+        }
+
+        // 2. Hysteresis. With the default route on neither tunnel (split tunnel — the common case
+        //    for GlobalProtect), several candidates stay equally valid indefinitely. Keeping the
+        //    existing choice is what stops the selection oscillating, and an oscillating selection
+        //    is not cosmetic: every flip is read as an interface change and re-issues the entire
+        //    route set, which is the feedback loop that destabilises the tunnel.
+        if let current, eligible.contains(where: { $0.interface == current }) {
+            return current
+        }
+
+        // 3. Deterministic tie-break, so two machines in the same state make the same choice and a
+        //    restart does not silently pick differently.
+        return eligible.map(\.interface).min(by: interfaceOrdersBefore)
+    }
+
+    /// Orders interfaces by NUMERIC suffix, not lexically — "utun10" must sort after "utun9",
+    /// which plain string comparison gets backwards.
+    static func interfaceOrdersBefore(_ a: String, _ b: String) -> Bool {
+        let sa = numericSuffix(a), sb = numericSuffix(b)
+        if let sa, let sb, sa != sb { return sa < sb }
+        let pa = a.prefix(while: { !$0.isNumber }), pb = b.prefix(while: { !$0.isNumber })
+        if pa != pb { return pa < pb }
+        return a < b
+    }
+
+    static func numericSuffix(_ s: String) -> Int? {
+        let digits = s.drop(while: { !$0.isNumber })
+        return digits.isEmpty ? nil : Int(digits)
+    }
+
+    /// The interface the default route exits through, from `route -n get default` output.
+    /// Pure so it can be tested without a routing table.
+    public static func parseDefaultRouteInterface(_ routeOutput: String) -> String? {
+        for line in routeOutput.components(separatedBy: "\n") {
+            let t = line.trimmingCharacters(in: .whitespaces)
+            if t.hasPrefix("interface:") {
+                let v = t.dropFirst("interface:".count).trimmingCharacters(in: .whitespaces)
+                return v.isEmpty ? nil : v
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -675,34 +675,68 @@ final class RouteManager: ObservableObject {
             }
         }
         
-        // Second pass: check corporate VPN IPs (async) and find valid VPN
-        var vpnCandidates: [(name: String, ip: String, isValid: Bool)] = []
-        
+        // Second pass: build the full candidate set, then choose deliberately.
+        //
+        // This used to return the FIRST interface that matched, in ifconfig order. Several tunnels
+        // being up at once is the ordinary case, not a corner case — a corporate client alongside
+        // Tailscale — and ifconfig order has nothing to do with which one carries traffic. Since
+        // Tailscale's utun usually sorts before a corporate client's, it won that race whenever an
+        // exit node made its address look like a VPN, and in VPN Only mode the catch-alls would
+        // then be installed to escape the WRONG tunnel, sending corporate traffic direct.
+        let tsIPs = await tailscaleSelfIPs()
+        var candidates: [VPNCandidate] = []
         for i in interfaces.indices {
             let isValid = await isCorporateVPNIP(interfaces[i].ip, hintType: hintType)
             interfaces[i].isValidCorporateIP = isValid
-            
-            // Track VPN candidates for debugging
-            if interfaces[i].isVPN {
-                vpnCandidates.append((interfaces[i].name, interfaces[i].ip, isValid))
-            }
-            
-            // Check if this is our VPN
-            if interfaces[i].isVPN && interfaces[i].hasUpFlag && isValid {
-                let vpnType = hintType ?? detectVPNTypeFromInterface(interfaces[i].name)
-                return (true, interfaces[i].name, vpnType)
-            }
+            guard interfaces[i].isVPN else { continue }
+            candidates.append(VPNCandidate(
+                interface: interfaces[i].name,
+                isUp: interfaces[i].hasUpFlag,
+                isTunnel: true,
+                isCorporateAddress: isValid,
+                isTailscale: tsIPs.contains(interfaces[i].ip)
+            ))
         }
-        
+
+        let defaultRouteInterface = await currentDefaultRouteInterface()
+        let selected = VPNInterfaceSelector.select(
+            candidates: candidates,
+            defaultRouteInterface: defaultRouteInterface,
+            current: vpnInterface
+        )
+
+        if let selected {
+            if candidates.filter({ $0.isUp && $0.isCorporateAddress && !$0.isTailscale }).count > 1 {
+                let all = candidates.map(\.interface).joined(separator: ", ")
+                await MainActor.run {
+                    log(.info, "Multiple tunnels up (\(all)) — using \(selected)" +
+                        (defaultRouteInterface == selected ? " (carries the default route)" : ""))
+                }
+            }
+            let type = hintType ?? detectVPNTypeFromInterface(selected)
+            return (true, selected, type)
+        }
+
         // Debug: log what we found if no VPN detected
-        if !vpnCandidates.isEmpty {
-            let summary = vpnCandidates.map { "\($0.name):\($0.ip) valid=\($0.isValid)" }.joined(separator: ", ")
+        if !candidates.isEmpty {
+            let summary = candidates.map {
+                "\($0.interface) up=\($0.isUp) corp=\($0.isCorporateAddress) tailscale=\($0.isTailscale)"
+            }.joined(separator: ", ")
             await MainActor.run { log(.info, "VPN candidates (none matched): \(summary)") }
         }
-        
+
         return (false, nil, nil)
     }
     
+    /// Which interface the default route currently exits through, or nil if unreadable.
+    /// This is the only direct evidence of which tunnel is actually carrying traffic.
+    private func currentDefaultRouteInterface() async -> String? {
+        guard let result = await runProcessAsync("/sbin/route", arguments: ["-n", "get", "default"], timeout: 5.0) else {
+            return nil
+        }
+        return VPNInterfaceSelector.parseDefaultRouteInterface(result.output)
+    }
+
     /// Check if interface name suggests it's a VPN interface
     private func isVPNInterface(_ iface: String) -> Bool {
         // Common VPN interface prefixes

--- a/Tests/VPNBypassTests/VPNInterfaceSelectorTests.swift
+++ b/Tests/VPNBypassTests/VPNInterfaceSelectorTests.swift
@@ -1,0 +1,164 @@
+// VPNInterfaceSelectorTests.swift
+// Coverage for choosing which tunnel is "the VPN" when several are up at once.
+//
+// Two tunnels at once is the ordinary case on this kind of machine — a corporate client alongside
+// Tailscale, on a Mac showing nine utun interfaces. Selection used to be "first match in ifconfig
+// order", which is neither deterministic nor related to which tunnel carries traffic. Because
+// Tailscale's utun typically sorts BEFORE a corporate client's, Tailscale won that race whenever an
+// exit node made its address look like a VPN — and in VPN Only mode the catch-alls are then
+// installed to escape the tunnel the app picked, sending the OTHER tunnel's corporate traffic
+// straight out. That is a leak, not a cosmetic misselection.
+
+import XCTest
+@testable import VPNBypassCore
+
+final class VPNInterfaceSelectorTests: XCTestCase {
+
+    private func c(_ iface: String, up: Bool = true, corp: Bool = true, ts: Bool = false) -> VPNCandidate {
+        VPNCandidate(interface: iface, isUp: up, isTunnel: true, isCorporateAddress: corp, isTailscale: ts)
+    }
+
+    // MARK: - Tailscale must never be selected
+
+    /// The leak case, exactly as it occurs live: Tailscale on a LOWER-numbered utun than the
+    /// corporate client, so ifconfig order would have handed it the selection.
+    func testCorporateTunnelWinsOverLowerNumberedTailscale() {
+        let picked = VPNInterfaceSelector.select(
+            candidates: [c("utun4", ts: true), c("utun9")],
+            defaultRouteInterface: nil, current: nil)
+        XCTAssertEqual(picked, "utun9")
+    }
+
+    /// Tailscale alone — mesh or exit node — is not "the VPN". Selecting it would make the app
+    /// reroute mesh traffic, which is not what any of its modes are for.
+    func testTailscaleAloneIsNotAVPN() {
+        XCTAssertNil(VPNInterfaceSelector.select(
+            candidates: [c("utun4", ts: true)], defaultRouteInterface: nil, current: nil))
+    }
+
+    /// Even holding the default route, Tailscale must not be selected — an exit node legitimately
+    /// carries the default route, and that still does not make it the tunnel to reroute.
+    func testTailscaleIsNotSelectedEvenWhenItHoldsTheDefaultRoute() {
+        XCTAssertNil(VPNInterfaceSelector.select(
+            candidates: [c("utun4", ts: true)], defaultRouteInterface: "utun4", current: nil))
+    }
+
+    // MARK: - Ground truth
+
+    func testTunnelCarryingTheDefaultRouteIsPreferred() {
+        let picked = VPNInterfaceSelector.select(
+            candidates: [c("utun3"), c("utun9")],
+            defaultRouteInterface: "utun9", current: nil)
+        XCTAssertEqual(picked, "utun9", "the tunnel actually moving traffic outranks any heuristic")
+    }
+
+    /// A default route that moved to a different tunnel is a real change and must override the
+    /// previous choice — otherwise routes stay pinned to a tunnel no longer carrying traffic.
+    func testDefaultRouteOutranksTheExistingSelection() {
+        let picked = VPNInterfaceSelector.select(
+            candidates: [c("utun3"), c("utun9")],
+            defaultRouteInterface: "utun9", current: "utun3")
+        XCTAssertEqual(picked, "utun9")
+    }
+
+    /// A default route over ordinary Ethernet (split tunnel — the normal GlobalProtect case) names
+    /// no candidate, so selection falls through rather than dropping the VPN.
+    func testDefaultRouteOnPhysicalInterfaceDoesNotDeselectTheVPN() {
+        let picked = VPNInterfaceSelector.select(
+            candidates: [c("utun9")], defaultRouteInterface: "en8", current: nil)
+        XCTAssertEqual(picked, "utun9")
+    }
+
+    // MARK: - Hysteresis
+
+    /// The churn guard. With several candidates equally valid and no default route to separate
+    /// them, the choice must not oscillate: every flip reads as an interface change and re-issues
+    /// the entire route set, which is the feedback loop that destabilises the tunnel (#65).
+    func testSelectionIsStickyWhenSeveralCandidatesRemainValid() {
+        let cands = [c("utun3"), c("utun9")]
+        XCTAssertEqual(VPNInterfaceSelector.select(candidates: cands, defaultRouteInterface: nil, current: "utun9"), "utun9")
+        XCTAssertEqual(VPNInterfaceSelector.select(candidates: cands, defaultRouteInterface: nil, current: "utun3"), "utun3")
+    }
+
+    /// Stickiness must not outlive the interface: once the held tunnel drops, selection moves on.
+    func testStickinessEndsWhenTheHeldInterfaceGoesAway() {
+        let picked = VPNInterfaceSelector.select(
+            candidates: [c("utun3")], defaultRouteInterface: nil, current: "utun9")
+        XCTAssertEqual(picked, "utun3")
+    }
+
+    /// Repeated evaluation with unchanged inputs must return the same answer — an unstable
+    /// selection is itself a source of route churn.
+    func testRepeatedEvaluationIsStable() {
+        let cands = [c("utun9"), c("utun4", ts: true), c("utun3")]
+        var current: String? = nil
+        var seen: Set<String> = []
+        for _ in 0..<10 {
+            current = VPNInterfaceSelector.select(candidates: cands, defaultRouteInterface: nil, current: current)
+            seen.insert(current ?? "nil")
+        }
+        XCTAssertEqual(seen.count, 1, "selection must converge, not oscillate: \(seen)")
+    }
+
+    // MARK: - Eligibility
+
+    func testDownAndNonCorporateInterfacesAreIgnored() {
+        XCTAssertNil(VPNInterfaceSelector.select(
+            candidates: [c("utun3", up: false), c("utun5", corp: false)],
+            defaultRouteInterface: nil, current: nil))
+    }
+
+    func testNoCandidatesYieldsNoSelection() {
+        XCTAssertNil(VPNInterfaceSelector.select(candidates: [], defaultRouteInterface: nil, current: nil))
+    }
+
+    // MARK: - Deterministic ordering
+
+    /// Numeric, not lexical: plain string comparison puts "utun10" before "utun9".
+    func testTieBreakOrdersNumericallyNotLexically() {
+        let picked = VPNInterfaceSelector.select(
+            candidates: [c("utun10"), c("utun9")], defaultRouteInterface: nil, current: nil)
+        XCTAssertEqual(picked, "utun9")
+    }
+
+    /// Order of the input array must not change the answer — otherwise ifconfig ordering leaks
+    /// back in as a hidden input.
+    func testSelectionIsIndependentOfCandidateOrder() {
+        let a = VPNInterfaceSelector.select(candidates: [c("utun3"), c("utun9")], defaultRouteInterface: nil, current: nil)
+        let b = VPNInterfaceSelector.select(candidates: [c("utun9"), c("utun3")], defaultRouteInterface: nil, current: nil)
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(a, "utun3")
+    }
+
+    /// Non-utun tunnel names (ipsec, ppp) must order sanely rather than crash or compare oddly.
+    func testMixedInterfaceFamiliesOrderDeterministically() {
+        let picked = VPNInterfaceSelector.select(
+            candidates: [c("utun9"), c("ipsec0")], defaultRouteInterface: nil, current: nil)
+        XCTAssertEqual(picked, "ipsec0")
+    }
+
+    // MARK: - Default route parsing
+
+    func testParsesDefaultRouteInterface() {
+        let out = """
+           route to: default
+        destination: default
+               mask: default
+            gateway: 10.167.222.191
+          interface: utun9
+              flags: <UP,GATEWAY,DONE,STATIC,PRCLONING,GLOBAL>
+        """
+        XCTAssertEqual(VPNInterfaceSelector.parseDefaultRouteInterface(out), "utun9")
+    }
+
+    func testParsesInterfaceWhenNoGatewayLineIsPresent() {
+        // Cisco-style link routes report an interface and no gateway at all (#26).
+        let out = "   route to: default\n  interface: utun4\n      flags: <UP,DONE>"
+        XCTAssertEqual(VPNInterfaceSelector.parseDefaultRouteInterface(out), "utun4")
+    }
+
+    func testUnparseableRouteOutputYieldsNil() {
+        XCTAssertNil(VPNInterfaceSelector.parseDefaultRouteInterface(""))
+        XCTAssertNil(VPNInterfaceSelector.parseDefaultRouteInterface("route: writing to routing socket: not in table"))
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to VPN Bypass will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **With two VPNs running, the app could pick the wrong one.** Several tunnels being up at once is ordinary — a corporate VPN alongside Tailscale — but the app took the first one it happened to see, which had nothing to do with which tunnel was carrying traffic. Because Tailscale usually appears earlier in that list, it could win, and in VPN Only mode the app would then install its rules to escape the wrong tunnel and send the other one's traffic straight out. It now prefers the tunnel actually carrying the default route, never picks Tailscale, keeps its choice stable while several remain valid, and breaks any remaining tie the same way every time.
+
 ## [3.1.13] - 2026-08-07
 
 ### Fixed

--- a/docs/COEXISTENCE.md
+++ b/docs/COEXISTENCE.md
@@ -1,0 +1,110 @@
+# Running alongside other VPNs and local proxies
+
+VPN Bypass is rarely the only thing touching the network. A typical machine runs a corporate VPN
+client, a mesh VPN such as Tailscale, and one or more local proxies at the same time. This page
+states exactly what VPN Bypass will and will not do in that situation, so you can predict its
+behaviour instead of discovering it.
+
+The short version: **VPN Bypass acts on one tunnel — the corporate VPN — and leaves everything else
+alone.**
+
+---
+
+## What VPN Bypass can and cannot control
+
+VPN Bypass works by adding entries to the system routing table. That single fact explains most of
+what follows.
+
+**It can** decide, per destination IP, whether traffic goes through the VPN or around it.
+
+**It cannot** decide anything per application. macOS only offers per-process network control through
+a Network Extension, and this app deliberately does not use one — that is what keeps it installable
+without special entitlements. So there is no way to say "this proxy goes direct, everything else
+goes through the VPN". Rules are about *where traffic is going*, never about *what sent it*.
+
+---
+
+## Two VPNs at once
+
+When several tunnels are up, VPN Bypass picks exactly one to act on, in this order:
+
+1. **The tunnel carrying the default route.** This is direct evidence of which tunnel is actually
+   moving traffic, so nothing outranks it.
+2. **The tunnel it already chose**, as long as that is still valid. Under a split tunnel — the
+   normal case for most corporate clients — several tunnels can look equally valid indefinitely.
+   Sticking with the existing choice matters more than it sounds: every change of mind is treated as
+   the VPN having changed, which rebuilds the whole route set, and repeatedly rebuilding the route
+   set is what destabilises a tunnel in the first place.
+3. **A fixed tie-break**, so the same machine in the same state always makes the same choice, and a
+   restart never silently picks differently.
+
+### Tailscale is never chosen
+
+Tailscale is excluded from that selection entirely — including when it is acting as an exit node and
+carrying the default route.
+
+This is deliberate. Tailscale's traffic is not what any of the app's modes are meant to reroute, and
+choosing it would be actively harmful: in **VPN Only** mode the app installs catch-all rules to force
+traffic around the tunnel it selected. If it selected the wrong tunnel, the *other* tunnel's traffic
+goes straight out. Excluding Tailscale removes that failure entirely.
+
+If you want traffic to egress via a Tailscale peer, use a **Tailscale Peer** rule in Custom mode.
+That is a separate, explicit mechanism.
+
+### Addresses that are never touched
+
+Some destinations are refused outright, in the privileged helper rather than the app — so the refusal
+holds no matter what the app asks for:
+
+| Destination | Why |
+|---|---|
+| `100.64.0.0/10`, or any prefix covering it | Tailscale's own range. Routing it would silently redirect or delete Tailscale's route. |
+| `100.100.100.100` | Tailscale MagicDNS. |
+| `127.0.0.0/8` | Loopback — see the proxy section below. |
+| `169.254.0.0/16`, `224.0.0.0/4`, `255.255.255.255` | Kernel-reserved. |
+| `0.0.0.0/0` | The whole internet in one rule; the app expresses this as two halves so it can be reasoned about and torn down safely. |
+
+Individual addresses *inside* `100.64.0.0/10` are **not** blanket-refused, because that range is
+shared with Zscaler and Cloudflare WARP, and blocking all of it would break legitimate rules for
+those clients.
+
+---
+
+## Local proxies
+
+A local proxy listens on loopback (`127.0.0.1:<port>`) and makes its own outbound connection to some
+upstream server.
+
+**The listener is never affected.** `127.0.0.0/8` is refused by the privileged helper, so no rule,
+in any mode, can route loopback traffic. Applications talking to a local proxy keep working
+regardless of what VPN Bypass is doing. This holds for any number of proxies on any number of ports.
+
+**The upstream follows the mode you chose**, like any other destination:
+
+- **Bypass mode** — only the destinations you list are routed around the VPN. A proxy's upstream is
+  unaffected unless you list it.
+- **VPN Only mode** — everything not listed goes direct, *including* proxy upstreams. This is the
+  mode's entire purpose, but it is worth stating plainly: a proxy that was reaching its upstream
+  through the VPN will stop doing so.
+- **Custom mode** — each rule decides for itself.
+
+If a proxy's upstream must stay inside the corporate VPN, add it as a **VPN Only** entry (or a
+Custom rule targeting the VPN) so it is routed through the tunnel explicitly rather than left to the
+catch-all.
+
+---
+
+## Checking what is actually happening
+
+```sh
+# Which tunnel currently carries the default route
+route -n get default
+
+# Every tunnel that is up
+ifconfig | grep -E '^(utun|ipsec|ppp)[0-9]+'
+
+# Tailscale's own addresses, to confirm which tunnel is Tailscale's
+tailscale status --json | grep -A3 TailscaleIPs
+```
+
+The app's log names the tunnel it selected, and says so explicitly whenever more than one is up.


### PR DESCRIPTION
Running a corporate VPN and Tailscale at the same time is ordinary, not a corner case. This machine shows **nine** utun interfaces.

## Cause

`detectVPNViaIfconfig` returned the **first** interface that matched, in `ifconfig` order. That order has nothing to do with which tunnel carries traffic.

Tailscale's utun typically sorts *before* a corporate client's, so Tailscale won that race whenever an exit node made its address look like a VPN. That is a **leak**, not a cosmetic misselection: VPN Only installs its catch-alls to escape the tunnel the app selected, so the corporate traffic on the *other* tunnel goes direct.

## Fix — `VPNInterfaceSelector`, pure and testable

1. **Prefer the tunnel carrying the default route.** The only direct evidence of which tunnel actually moves traffic. Deliberately outranks hysteresis, because a default-route move is a real change.
2. **Otherwise keep the current selection while it stays eligible.** Under a split tunnel (the normal GlobalProtect case) several candidates stay equally valid indefinitely, and an oscillating selection reads as an interface change on every pass — re-issuing the entire route set. That is the #65 feedback loop.
3. **Deterministic numeric tie-break**, so the answer does not depend on `ifconfig` ordering, array ordering, or restart timing.

**Tailscale is excluded outright**, including when it holds the default route as an exit node: mesh traffic is not what any of the app's modes reroute, and Tailscale egress already has its own route type.

## Tests

17 new, covering the leak case (Tailscale on a lower-numbered utun than the corporate tunnel), exit-node handling, default-route preference, stickiness and convergence, numeric ordering (`utun10` after `utun9`), order independence, and route parsing with and without a gateway line.

`919 tests, 0 failures`.

Refs #65