### PR TITLE
fix: close both quit-teardown races that stranded kernel routes

### DIFF
--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -27,6 +27,21 @@ final class RouteManager: ObservableObject {
     @Published var routeVerificationResults: [String: RouteVerificationResult] = [:]
     @Published var isLoading = true
     @Published private(set) var isApplyingRoutes = false
+
+    /// True once shutdown has begun. Checked by the operation gate (so no new route
+    /// operation can start) and by the tracked batch-add wrapper (so an operation
+    /// already past the gate cannot push more routes into the kernel mid-teardown).
+    private(set) var isShuttingDown = false
+
+    /// Kernel-visible destinations that may not (yet, or ever) be recorded in
+    /// `activeRoutes`. Recorded BEFORE every batch add, so quit teardown can remove
+    /// routes the in-memory model never got to track: the epoch guard deliberately
+    /// skips the model append after preemption, which once left 93 kernel routes
+    /// with no record anywhere (2026-08-07).
+    var pendingKernelAdds: Set<String> = []
+
+    /// Handle for the fire-and-forget background DNS refresh, so shutdown can cancel it.
+    private var backgroundRefreshTask: Task<Void, Never>?
     @Published var lastDNSRefresh: Date?
     @Published var nextDNSRefresh: Date?
     @Published var isTestingProxy = false
@@ -44,7 +59,7 @@ final class RouteManager: ObservableObject {
     private var dnsCache: [String: String] = [:]  // Cache: domain -> first resolved IP (for hosts file)
     private var dnsDiskCache: [String: [String]] = [:]  // Persistent cache: domain -> all resolved IPs
     private var orphanedServiceDomains: [String: [String]] = [:]  // Deleted service name -> its domains (for hosts reconstruction)
-    private var routeEpoch: UInt64 = 0  // Incremented by removeAllRoutes — lets in-flight applies detect preemption
+    private(set) var routeEpoch: UInt64 = 0  // Incremented by removeAllRoutes — lets in-flight applies detect preemption
     private var gatewayDetectedAt: Date?
     private var lastInterfaceReroute: Date?
     /// A re-route (interface change or Tailscale profile change) that was NEEDED but
@@ -1118,8 +1133,10 @@ final class RouteManager: ObservableObject {
                     log(.info, "Routes applied from cache. Refreshing DNS in background...")
                 }
                 
-                // Background refresh: re-resolve DNS and update routes if changed
-                Task.detached { [weak self] in
+                // Background refresh: re-resolve DNS and update routes if changed.
+                // The handle is stored so beginShutdown() can cancel it — unowned, this
+                // task once raced quit teardown and re-added 93 routes after removal.
+                backgroundRefreshTask = Task.detached { [weak self] in
                     await self?.backgroundDNSRefresh(sendNotification: sendNotification)
                 }
             } else {
@@ -1446,7 +1463,7 @@ final class RouteManager: ObservableObject {
         var batchFailedDests: Set<String> = []
         if HelperManager.shared.isHelperInstalled {
             let helperRoutes = routesToAdd.map { (destination: $0.destination, gateway: $0.gateway, isNetwork: $0.isNetwork) }
-            let result = await HelperManager.shared.addRoutesBatch(routes: helperRoutes)
+            let result = await addRoutesBatchTracked(routes: helperRoutes)
             batchFailureCount = result.failureCount
             batchFailedDests = Set(result.failedDestinations)
 
@@ -1579,7 +1596,7 @@ final class RouteManager: ObservableObject {
         if !routesToAdd.isEmpty {
             if HelperManager.shared.isHelperInstalled {
                 let helperRoutes = routesToAdd.map { (destination: $0.destination, gateway: $0.gateway, isNetwork: $0.isNetwork) }
-                let result = await HelperManager.shared.addRoutesBatch(routes: helperRoutes)
+                let result = await addRoutesBatchTracked(routes: helperRoutes)
                 batchFailureCount = result.failureCount
                 batchFailedDests = Set(result.failedDestinations)
                 if result.failureCount > 0 {
@@ -1719,7 +1736,10 @@ final class RouteManager: ObservableObject {
     /// Increments routeEpoch so in-flight applies detect preemption and abort before committing.
     func removeAllRoutes() async {
         routeEpoch &+= 1
-        let destinations = Array(Set(activeRoutes.map { $0.destination }))
+        // Sweep the union of what the model tracks AND what was pushed to the kernel but
+        // never committed (pendingKernelAdds) — the latter is invisible to the model by
+        // design of the epoch guard, and was the strand mechanism on 2026-08-07.
+        let destinations = Array(Set(activeRoutes.map { $0.destination }).union(pendingKernelAdds))
 
         var failedDests: Set<String> = []
         if !destinations.isEmpty {
@@ -1760,6 +1780,14 @@ final class RouteManager: ObservableObject {
         }
 
         cancelAllRetries()
+        // A failed removal must keep its record. The retention filter below only keeps entries
+        // already in activeRoutes — a pending-only destination (pushed to the kernel but never
+        // committed to the model) would lose its record here, so append one first.
+        let trackedBeforeRetention = Set(activeRoutes.map { $0.destination })
+        for dest in failedDests where !trackedBeforeRetention.contains(dest) && pendingKernelAdds.contains(dest) {
+            activeRoutes.append(ActiveRoute(destination: dest, gateway: localGateway ?? "", source: "pending-sweep-retry", timestamp: Date()))
+        }
+        pendingKernelAdds.removeAll()
         if !failedDests.isEmpty {
             // Retain entries for destinations that failed kernel removal — they're still live
             activeRoutes.removeAll { !failedDests.contains($0.destination) }
@@ -1879,7 +1907,7 @@ final class RouteManager: ObservableObject {
         if !routesToAdd.isEmpty {
             if HelperManager.shared.isHelperInstalled {
                 let helperRoutes = routesToAdd.map { (destination: $0.destination, gateway: $0.gateway, isNetwork: $0.isNetwork) }
-                let result = await HelperManager.shared.addRoutesBatch(routes: helperRoutes)
+                let result = await addRoutesBatchTracked(routes: helperRoutes)
                 batchFailureCount = result.failureCount
                 batchFailedDests = Set(result.failedDestinations)
                 if result.failureCount > 0 {
@@ -1962,6 +1990,9 @@ final class RouteManager: ObservableObject {
             }
             log(.warning, "🔧 \(failed.count) route(s) failed kernel removal during unstrand — retained in activeRoutes so the next teardown removes them")
         }
+        // Every attempted destination is now either out of the kernel or retained in
+        // activeRoutes — either way it is no longer pending.
+        pendingKernelAdds.subtract(attempted)
     }
 
     /// Shared install-epilogue for the two full-replace apply paths
@@ -2041,6 +2072,8 @@ final class RouteManager: ObservableObject {
         }
 
         activeRoutes = newRoutes
+        // Committed destinations are tracked in activeRoutes now — no longer pending.
+        pendingKernelAdds.subtract(newRoutes.map { $0.destination })
         lastUpdate = Date()
 
         // Manage hosts file if enabled
@@ -2234,7 +2267,7 @@ final class RouteManager: ObservableObject {
                     guard seenAddDests.insert(add.destination).inserted else { return nil }
                     return (destination: add.destination, gateway: add.gateway, isNetwork: add.isNetwork)
                 }
-                let result = await HelperManager.shared.addRoutesBatch(routes: routes)
+                let result = await addRoutesBatchTracked(routes: routes)
                 addFailedDests = Set(result.failedDestinations)
                 passAddedDests.formUnion(Set(routes.map { $0.destination }).subtracting(addFailedDests))
 
@@ -3513,7 +3546,7 @@ final class RouteManager: ObservableObject {
         // Apply new kernel routes in single batch, exclude failed destinations from ownership
         var failedDests: Set<String> = []
         if !routesToAdd.isEmpty && HelperManager.shared.isHelperInstalled {
-            let result = await HelperManager.shared.addRoutesBatch(routes: routesToAdd)
+            let result = await addRoutesBatchTracked(routes: routesToAdd)
             failedDests = Set(result.failedDestinations)
             if result.failureCount > 0 {
                 log(.warning, "Batch route add for \(service.name): \(result.successCount) succeeded, \(result.failureCount) failed")
@@ -3658,10 +3691,27 @@ final class RouteManager: ObservableObject {
     
     // MARK: - Private Methods
     
+    /// The only sanctioned way to batch-add routes to the kernel. Records destinations as
+    /// pending BEFORE the write (so teardown can always find them) and refuses outright once
+    /// shutdown has begun (so nothing lands mid-teardown).
+    func addRoutesBatchTracked(
+        routes: [(destination: String, gateway: String, isNetwork: Bool)]
+    ) async -> (successCount: Int, failureCount: Int, failedDestinations: [String], error: String?) {
+        guard !isShuttingDown else {
+            log(.warning, "Refusing batch add of \(routes.count) route(s): shutdown in progress")
+            return (0, routes.count, routes.map { $0.destination }, "shutdown in progress")
+        }
+        pendingKernelAdds.formUnion(routes.map { $0.destination })
+        let result = await HelperManager.shared.addRoutesBatch(routes: routes)
+        // Failed destinations never reached the kernel — nothing to sweep for them.
+        pendingKernelAdds.subtract(result.failedDestinations)
+        return result
+    }
+
     /// Acquire exclusive route operation lock. Returns false if another operation is running.
     /// @MainActor guarantees atomic check-and-set between await suspension points.
     private func acquireRouteOperation() -> Bool {
-        guard !isApplyingRoutes else { return false }
+        guard !isShuttingDown, !isApplyingRoutes else { return false }
         isApplyingRoutes = true
         return true
     }
@@ -4142,12 +4192,46 @@ final class RouteManager: ObservableObject {
     }
     
     /// Called when app is quitting - clean up routes and hosts file
+    /// Synchronously flips the shutdown flag and cancels every background task that could
+    /// mutate routes. Must be the FIRST thing both quit paths do — before any `await`.
+    /// Test-only: reverses beginShutdown so shared-singleton tests can restore state.
+    func resetShutdownStateForTests() {
+        isShuttingDown = false
+    }
+
+    /// Test-only seams for the operation gate (it is private by design).
+    func tryAcquireRouteOperationForTests() -> Bool { acquireRouteOperation() }
+    func releaseRouteOperationForTests() { releaseRouteOperation() }
+
+    func beginShutdown() {
+        guard !isShuttingDown else { return }
+        isShuttingDown = true
+        backgroundRefreshTask?.cancel()
+        rerouteRetryTask?.cancel()
+        rerouteRetryTask = nil
+        cancelAllRetries()
+    }
+
     func cleanupOnQuit() async {
+        beginShutdown()
         log(.info, "Cleaning up on quit...")
         ProxyListenerManager.shared.stopAll()
-        // Always remove active routes (especially critical for VPN Only catch-alls)
-        if !activeRoutes.isEmpty {
-            await removeAllRoutes()
+        // ALWAYS run teardown — even with an empty model. Its epoch bump is what preempts
+        // an in-flight apply; skipping it when `activeRoutes` was empty let a quit that
+        // landed mid-apply finish installing its full set after "cleanup" had completed.
+        await removeAllRoutes()
+        // An operation that was already past the gate may still be draining. Wait briefly
+        // (bounded — never blocks quit), then sweep anything it pushed into the kernel.
+        var polls = 0
+        while isApplyingRoutes && polls < 30 {
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            polls += 1
+        }
+        if !pendingKernelAdds.isEmpty {
+            let residual = Array(pendingKernelAdds)
+            log(.warning, "Quit sweep: removing \(residual.count) route(s) installed during teardown")
+            _ = await removeRoutesBatchVia(residual)
+            pendingKernelAdds.removeAll()
         }
         if config.manageHostsFile {
             await cleanHostsFile()

--- a/Sources/VPNBypassCore/VPNBypassApp.swift
+++ b/Sources/VPNBypassCore/VPNBypassApp.swift
@@ -147,6 +147,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             let source = DispatchSource.makeSignalSource(signal: sig, queue: .main)
             source.setEventHandler {
                 Task { @MainActor in
+                    self.beginAppShutdown()
+                    // Same safety deadline as the menu-quit path — this path previously had
+                    // none, so a wedged helper XPC could hold the process open indefinitely.
+                    let deadline = Self.quitDeadlineSeconds()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + deadline) {
+                        RouteManager.shared.log(.warning, "Signal teardown exceeded \(Int(deadline))s — exiting")
+                        exit(0)
+                    }
                     await RouteManager.shared.cleanupOnQuit()
                     exit(0)
                 }
@@ -157,16 +165,34 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
 
-    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        // Hide all UI immediately so quit feels instant
-        NSApp.windows.forEach { $0.orderOut(nil) }
-
+    /// Shared first step of BOTH quit paths — menu quit and SIGTERM/SIGINT (the latter is
+    /// what `brew upgrade`'s pkill delivers, and it previously performed none of these stops,
+    /// so timers and monitors kept firing route work during teardown).
+    @MainActor private func beginAppShutdown() {
         controlServer?.stop()
         networkMonitor?.cancel()
         refreshTimer?.invalidate()
         watchdogTimer?.invalidate()
         networkDebounceWorkItem?.cancel()
         RouteManager.shared.stopDNSRefreshTimer()
+        RouteManager.shared.beginShutdown()
+    }
+
+    /// The teardown budget. Scales with tracked routes — but a quit that lands MID-APPLY
+    /// reads a still-empty model while hundreds of routes are installing; that under-sized
+    /// the budget to 8s once while 319 routes landed, so an in-flight apply floors it.
+    @MainActor static func quitDeadlineSeconds() -> Double {
+        if RouteManager.shared.isApplyingRoutes { return 60.0 }
+        let trackedRouteCount = RouteManager.shared.activeRoutes.count
+        return min(60.0, 8.0 + Double(trackedRouteCount) * 0.15)
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        // Hide all UI immediately so quit feels instant
+        NSApp.windows.forEach { $0.orderOut(nil) }
+
+        // applicationShouldTerminate is delivered on the main thread.
+        MainActor.assumeIsolated { beginAppShutdown() }
 
         // Clean up routes and hosts file on quit, then allow termination.
         //
@@ -180,8 +206,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         //
         // Catch-alls are torn down first (see removeAllRoutes), so the most leak-relevant work is
         // done early; this budget is about not abandoning the remainder.
-        let trackedRouteCount = RouteManager.shared.activeRoutes.count
-        let quitDeadline = min(60.0, 8.0 + Double(trackedRouteCount) * 0.15)
+        let quitDeadline = MainActor.assumeIsolated { Self.quitDeadlineSeconds() }
         var didReply = false
         DispatchQueue.main.asyncAfter(deadline: .now() + quitDeadline) {
             guard !didReply else { return }

--- a/Tests/VPNBypassTests/ShutdownRaceTests.swift
+++ b/Tests/VPNBypassTests/ShutdownRaceTests.swift
@@ -1,0 +1,132 @@
+// ShutdownRaceTests.swift
+// Regression coverage for the two quit races proven live on 2026-08-07:
+//
+// Race 1 — the compensation-after-commit hole. Teardown deliberately skips the operation gate
+// and preempts in-flight work via an epoch bump; but the in-flight apply's kernel batch-add ran
+// BEFORE its epoch check, and quit killed the process before the compensating removal executed.
+// Result: 93 routes in the kernel with no record in `activeRoutes` — invisible to any future
+// teardown, because the epoch guard had (correctly) skipped the model append.
+//
+// Race 2 — the quit-mid-apply hole. `cleanupOnQuit` guarded teardown with
+// `if !activeRoutes.isEmpty`; a quit landing during a startup apply saw an empty model, skipped
+// `removeAllRoutes`, therefore never bumped the epoch, and the in-flight apply finished
+// installing all 319 routes AFTER "cleanup" completed.
+//
+// The fixes under test: a shutdown flag refusing new work at the gate and at the batch-add
+// wrapper; destinations recorded as pending BEFORE every kernel add; teardown sweeping the union
+// of tracked + pending; pending-only failures retained as records; the epoch always bumped.
+//
+// The helper is never installed in the test environment, so helper-path calls fail fast — which
+// is exactly the path these tests need.
+
+import XCTest
+@testable import VPNBypassCore
+
+@MainActor
+final class ShutdownRaceTests: XCTestCase {
+
+    private var savedRoutes: [RouteManager.ActiveRoute] = []
+    private var savedPending: Set<String> = []
+
+    override func setUp() {
+        super.setUp()
+        savedRoutes = RouteManager.shared.activeRoutes
+        savedPending = RouteManager.shared.pendingKernelAdds
+        RouteManager.shared.activeRoutes = []
+        RouteManager.shared.pendingKernelAdds = []
+    }
+
+    override func tearDown() {
+        RouteManager.shared.resetShutdownStateForTests()
+        RouteManager.shared.activeRoutes = savedRoutes
+        RouteManager.shared.pendingKernelAdds = savedPending
+        super.tearDown()
+    }
+
+    // MARK: - Shutdown flag
+
+    func testBeginShutdownFlipsFlagAndIsIdempotent() {
+        let rm = RouteManager.shared
+        XCTAssertFalse(rm.isShuttingDown)
+        rm.beginShutdown()
+        XCTAssertTrue(rm.isShuttingDown)
+        rm.beginShutdown() // second call must be harmless
+        XCTAssertTrue(rm.isShuttingDown)
+    }
+
+    /// Once shutdown begins, the batch-add wrapper must refuse WITHOUT contacting the helper and
+    /// WITHOUT recording pending destinations — nothing may land in the kernel mid-teardown.
+    func testBatchAddRefusesDuringShutdown() async {
+        let rm = RouteManager.shared
+        rm.beginShutdown()
+        let result = await rm.addRoutesBatchTracked(routes: [
+            (destination: "203.0.113.1", gateway: "192.168.1.1", isNetwork: false),
+            (destination: "203.0.113.2", gateway: "192.168.1.1", isNetwork: false),
+        ])
+        XCTAssertEqual(result.failureCount, 2)
+        XCTAssertEqual(Set(result.failedDestinations), ["203.0.113.1", "203.0.113.2"])
+        XCTAssertNotNil(result.error)
+        XCTAssertTrue(rm.pendingKernelAdds.isEmpty,
+                      "a refused add must not leave pending records — there is nothing to sweep")
+    }
+
+    // MARK: - Pending bookkeeping
+
+    /// A failed add (helper not ready here) must not leak pending records: destinations are
+    /// recorded BEFORE the write, and failures — which never reached the kernel — subtracted after.
+    func testFailedAddDoesNotLeakPendingRecords() async {
+        let rm = RouteManager.shared
+        let result = await rm.addRoutesBatchTracked(routes: [
+            (destination: "203.0.113.3", gateway: "192.168.1.1", isNetwork: false),
+        ])
+        XCTAssertEqual(result.failureCount, 1, "helper is not installed in tests — the add must fail")
+        XCTAssertTrue(rm.pendingKernelAdds.isEmpty)
+    }
+
+    // MARK: - Teardown sweeps pending (Race 1)
+
+    /// Teardown must attempt destinations the model never tracked — and when removal fails
+    /// (helper not ready), the pending-only destination must be RETAINED as a record, not
+    /// silently forgotten. Losing the record was the original strand mechanism.
+    func testRemoveAllRoutesSweepsPendingAndRetainsFailures() async {
+        let rm = RouteManager.shared
+        rm.pendingKernelAdds = ["203.0.113.9"]  // kernel-visible, never committed to the model
+        await rm.removeAllRoutes()
+        XCTAssertTrue(rm.pendingKernelAdds.isEmpty, "pending is consumed by teardown")
+        XCTAssertTrue(rm.activeRoutes.contains { $0.destination == "203.0.113.9" },
+                      "a pending-only destination that failed removal must keep a record")
+    }
+
+    // MARK: - Epoch always bumps (Race 2)
+
+    /// `cleanupOnQuit` must preempt an in-flight apply even when the model is empty — the epoch
+    /// bump IS the preemption signal, and skipping it was how a quit-mid-apply installed 319
+    /// routes after cleanup finished.
+    func testRemoveAllRoutesBumpsEpochEvenWhenEmpty() async {
+        let rm = RouteManager.shared
+        XCTAssertTrue(rm.activeRoutes.isEmpty)
+        XCTAssertTrue(rm.pendingKernelAdds.isEmpty)
+        let before = rm.routeEpoch
+        await rm.removeAllRoutes()
+        XCTAssertGreaterThan(rm.routeEpoch, before,
+                             "the epoch must advance even with nothing to remove")
+    }
+
+    /// The operation gate must refuse new work once shutdown began — and recover after reset.
+    func testGateRefusesAfterShutdown() throws {
+        let rm = RouteManager.shared
+        guard rm.tryAcquireRouteOperationForTests() else {
+            // Another test leaked the gate held — this test cannot own the invariant then.
+            throw XCTSkip("operation gate already held by unrelated state")
+        }
+        rm.releaseRouteOperationForTests()
+
+        rm.beginShutdown()
+        XCTAssertFalse(rm.tryAcquireRouteOperationForTests(),
+                       "the gate must refuse every new operation during shutdown")
+
+        rm.resetShutdownStateForTests()
+        XCTAssertTrue(rm.tryAcquireRouteOperationForTests(), "gate usable again after reset")
+        rm.releaseRouteOperationForTests()
+    }
+}


### PR DESCRIPTION
Phase 0 of [the improvement plan](https://github.com/GeiserX/VPN-Bypass/blob/main/docs/IMPROVEMENT-PLAN-2026-08.md) — the two proven quit races.

**Race 1 — compensation after the point of no return.** Teardown deliberately skips the operation gate and preempts in-flight applies via an epoch bump. But the in-flight apply's kernel batch-add runs *before* its epoch check, and quit kills the process before the compensating removal executes. The epoch guard then (correctly) skips the model append — leaving routes in the kernel with **no record anywhere** (observed live: 93 routes).

**Race 2 — quit mid-apply.** `cleanupOnQuit` guarded teardown with `!activeRoutes.isEmpty`. A quit landing during a startup apply sees an empty model → teardown skipped → epoch never bumps → the in-flight apply finishes installing its full set *after* cleanup completed (observed live: 319 routes).

## Fixes
- `isShuttingDown` set synchronously as the first act of **both** quit paths; checked in the operation gate — one edit covers every gated entry
- `addRoutesBatchTracked`: records destinations as pending **before** the kernel write; refuses during shutdown; all five call sites rerouted (and pending bookkeeping subtracts failures/commits/unstrands)
- `removeAllRoutes` sweeps tracked ∪ pending; pending-only failures get a retained record
- `cleanupOnQuit` always runs teardown, then bounded-waits and sweeps residuals
- SIGTERM path (what `brew upgrade`'s pkill delivers) unified with menu quit + gains a safety deadline
- Quit deadline floors to the cap while an apply is in flight

6 regression tests · `925 tests, 0 failures`

This is the structural fix for the stranded-route class behind #67.