### PR TITLE
feat!: subprocess-free route engine — PF_ROUTE socket, silent reconcile, ownership tags, startup sweep

### DIFF
--- a/Helper/HelperTool.swift
+++ b/Helper/HelperTool.swift
@@ -131,7 +131,7 @@ class HelperTool: NSObject, HelperProtocol {
         }
 
         Self.routeQueue.async {
-            let result = self.installRoute(destination: destination, gateway: gateway, isNetwork: isNetwork)
+            let result = self.installRoute(destination: destination, gateway: gateway, isNetwork: isNetwork, snapshot: self.kernelSnapshot())
             reply(result.success, result.error)
         }
     }
@@ -143,7 +143,7 @@ class HelperTool: NSObject, HelperProtocol {
         }
 
         Self.routeQueue.async {
-            let result = self.executeRoute(args: ["-n", "delete", destination])
+            let result = self.deleteRoute(destination: destination)
             if result.success {
                 helperLog.info("delete \(destination, privacy: .public): removed")
             } else {
@@ -162,6 +162,10 @@ class HelperTool: NSObject, HelperProtocol {
             var failedDestinations: [String] = []
             var lastError: String?
 
+            // ONE silent table read for the whole batch — replaces a forked, event-emitting
+            // `route -n get` per destination.
+            let snapshot = self.kernelSnapshot()
+
             for route in routes {
                 guard let destination = route["destination"] as? String,
                       let gateway = route["gateway"] as? String else {
@@ -178,7 +182,7 @@ class HelperTool: NSObject, HelperProtocol {
                     continue
                 }
 
-                let result = self.installRoute(destination: destination, gateway: gateway, isNetwork: isNetwork)
+                let result = self.installRoute(destination: destination, gateway: gateway, isNetwork: isNetwork, snapshot: snapshot)
                 if result.success {
                     successCount += 1
                 } else {
@@ -207,7 +211,7 @@ class HelperTool: NSObject, HelperProtocol {
                     continue
                 }
 
-                let result = self.executeRoute(args: ["-n", "delete", destination])
+                let result = self.deleteRoute(destination: destination)
                 if result.success {
                     successCount += 1
                 } else {
@@ -222,219 +226,167 @@ class HelperTool: NSObject, HelperProtocol {
         }
     }
 
-    /// Install one route WITHOUT the old blind `route delete` that preceded every add.
-    ///
-    /// #65: the previous `delete` + `add` pair cost two kernel mutations per route even when the
-    /// route was already correct, and — worse — it briefly REMOVED the route. Each mutation raises a
-    /// kernel route-change event, and GlobalProtect re-validates its own gateway route on every one;
-    /// its teardowns were preceded by `Failed to find route for <gateway>`, exactly what a transient
-    /// removal produces. The blind delete could also remove a route this app never owned.
-    ///
-    /// The ladder below never opens a window where the destination has no route:
-    ///   1. `change` — rewrites an existing route in place (one mutation, no gap). Succeeds in the
-    ///      re-apply case, which is the common one.
-    ///   2. `add` — only when nothing was there to change (one mutation).
-    ///   3. `delete` + `add` — last resort, only if `add` reports the route already exists (a race
-    ///      with another writer between steps 1 and 2). This is the sole path that can still open a
-    ///      gap, and it is now rare rather than universal.
-    private func installRoute(destination: String, gateway: String, isNetwork: Bool) -> (success: Bool, error: String?) {
-        // #65, the core of it: if the kernel ALREADY has exactly this route, write nothing.
-        // Callers re-apply the same route set constantly (DNS refresh, failed-domain retries,
-        // status passes), and each redundant write raises a kernel route-change event that other
-        // VPN clients react to by re-validating their tunnel — which is the entire bug. Skipping
-        // the write is what makes steady state cost ZERO mutations.
-        if routeAlreadyCorrect(destination: destination, gateway: gateway, isNetwork: isNetwork) {
-            helperLog.debug("install \(destination, privacy: .public): already correct, no mutation")
-            return (true, nil)
-        }
+    // MARK: - Routing-socket engine
+    //
+    // Every route mutation goes through ONE owned PF_ROUTE socket instead of forking
+    // /sbin/route per operation. The fork/exec design was the traced root cause of the VPN
+    // instability this helper used to trigger: each exec opens its own routing socket and
+    // blocks with no timeout, and stacked execs starved other processes' route operations —
+    // including the corporate VPN client's own periodic gateway-route READ, whose timeout it
+    // misreads as "my gateway route was removed" and tears the tunnel down. A single socket
+    // with one in-flight request makes that starvation structurally impossible: no processes,
+    // errno straight from write(2), and reads replaced by a silent NET_RT_DUMP snapshot.
 
-        let changed = executeRoute(args: buildRouteArgs(verb: "change", destination: destination, gateway: gateway, isNetwork: isNetwork))
-        if changed.success {
-            helperLog.info("install \(destination, privacy: .public): changed in place")
-            return (true, nil)
-        }
+    private var routeSocketFD: Int32 = -1
+    private var routeSeq: Int32 = 0
 
-        let added = executeRoute(args: buildRouteArgs(verb: "add", destination: destination, gateway: gateway, isNetwork: isNetwork))
-        if added.success {
+    /// Writes one routing message; returns nil on success or the errno on failure.
+    private func routeSocketPerform(type: Int32, spec: RouteKernel.Spec) -> Int32? {
+        if routeSocketFD < 0 {
+            routeSocketFD = socket(PF_ROUTE, SOCK_RAW, 0)
+            guard routeSocketFD >= 0 else { return errno }
+            // Outcomes come from write(2)'s errno — nothing is ever read from this socket, and
+            // an unread receive buffer on a long-lived routing socket would otherwise fill with
+            // every other process's routing chatter.
+            shutdown(routeSocketFD, SHUT_RD)
+        }
+        routeSeq &+= 1
+        guard let msg = RouteKernel.message(type: type, seq: routeSeq, spec: spec) else {
+            return EINVAL
+        }
+        let written = msg.withUnsafeBytes { raw in
+            write(routeSocketFD, raw.baseAddress, raw.count)
+        }
+        if written == msg.count { return nil }
+        let err = errno
+        if err == EBADF || err == EPIPE {
+            // Socket itself is broken — reopen on the next call.
+            close(routeSocketFD)
+            routeSocketFD = -1
+        }
+        return err
+    }
+
+    private func errnoString(_ err: Int32) -> String {
+        String(cString: strerror(err)) + " (errno \(err))"
+    }
+
+    /// Resolves the wire-format spec for a request. `iface:<name>` gateways become interface
+    /// indices here — if the interface vanished, that is a normal failure, not a crash.
+    private func specFor(destination: String, gateway: String, isNetwork: Bool) -> RouteKernel.Spec? {
+        if gateway.hasPrefix("iface:") {
+            let name = String(gateway.dropFirst(6))
+            let index = if_nametoindex(name)
+            guard index != 0 else { return nil }
+            return RouteKernel.Spec(destination: destination,
+                                    gateway: .interfaceIndex(UInt16(index)),
+                                    isNetwork: isNetwork)
+        }
+        return RouteKernel.Spec(destination: destination,
+                                gateway: .address(gateway),
+                                isNetwork: isNetwork)
+    }
+
+    /// Snapshot of the live table, indexed by destination string, restricted to entries that
+    /// could be "the route we would install": real static-kind entries, not kernel clones and
+    /// not reject/blackhole placeholders. One silent sysctl replaces a `route -n get` fork —
+    /// which also BROADCASTS a routing message to every listener — per destination.
+    private func kernelSnapshot() -> [String: RouteKernel.KernelRoute] {
+        guard let table = RouteKernel.currentTable() else { return [:] }
+        var index: [String: RouteKernel.KernelRoute] = [:]
+        for route in table {
+            guard route.flags & RTF_WASCLONED == 0,
+                  route.flags & RTF_REJECT == 0,
+                  route.flags & RTF_BLACKHOLE == 0 else { continue }
+            index[route.destinationString] = route
+        }
+        return index
+    }
+
+    /// Whether the kernel entry already IS the route we want — same kind, same egress.
+    /// Skipping the write on a match is what makes steady state cost zero kernel events.
+    private func kernelRouteMatches(_ kernel: RouteKernel.KernelRoute, spec: RouteKernel.Spec) -> Bool {
+        guard kernel.isHost == !spec.isNetwork else { return false }
+        switch spec.gateway {
+        case .address(let ip):
+            return kernel.gatewayAddress != nil
+                && RouteKernel.dotted(kernel.gatewayAddress!) == ip
+        case .interfaceIndex(let index):
+            return kernel.gatewayInterfaceIndex == index
+        }
+    }
+
+    /// The snapshot key a spec's destination corresponds to.
+    private func snapshotKey(destination: String, isNetwork: Bool) -> String {
+        guard isNetwork, let (network, prefix) = RouteCIDR.parse(destination) else {
+            return destination.hasSuffix("/32") ? String(destination.dropLast(3)) : destination
+        }
+        return "\(network)/\(prefix)"
+    }
+
+
+    /// Install one route via the routing socket, never opening a window where the destination
+    /// has no route:
+    ///   1. no-op — the snapshot says the kernel already has exactly this route (ZERO events;
+    ///      this is what makes a restart against an already-correct kernel completely silent).
+    ///   2. RTM_CHANGE — a different route exists for the destination: rewrite in place.
+    ///   3. RTM_ADD — nothing exists for it.
+    ///   4. cross-retry for the race in between: ADD refused with EEXIST → CHANGE.
+    private func installRoute(destination: String, gateway: String, isNetwork: Bool,
+                              snapshot: [String: RouteKernel.KernelRoute]) -> (success: Bool, error: String?) {
+        guard let spec = specFor(destination: destination, gateway: gateway, isNetwork: isNetwork) else {
+            return (false, "cannot resolve gateway \(gateway)")
+        }
+        let key = snapshotKey(destination: destination, isNetwork: isNetwork)
+        if let current = snapshot[key] {
+            if kernelRouteMatches(current, spec: spec) {
+                helperLog.debug("install \(destination, privacy: .public): already correct, no mutation")
+                return (true, nil)
+            }
+            // Route exists with a different egress — rewrite in place (one event, no gap).
+            if routeSocketPerform(type: RTM_CHANGE, spec: spec) == nil {
+                helperLog.info("install \(destination, privacy: .public): changed in place")
+                return (true, nil)
+            }
+        }
+        var err = routeSocketPerform(type: RTM_ADD, spec: spec)
+        if err == nil {
             helperLog.info("install \(destination, privacy: .public): added")
             return (true, nil)
         }
-
-        // `add` refused because a route for this destination exists after all — fall back to the
-        // old replace, which is the only remaining way to converge.
-        if (added.error ?? "").localizedCaseInsensitiveContains("exists") {
-            helperLog.info("install \(destination, privacy: .public): change+add both refused, replacing")
-            let removed = executeRoute(args: ["-n", "delete", destination])
-            guard removed.success else {
-                // Report why the removal failed rather than letting the follow-up add fail with a
-                // secondary "exists" that hides the real cause.
-                helperLog.error("install \(destination, privacy: .public): delete before replace failed: \(removed.error ?? "unknown", privacy: .public)")
-                return (false, removed.error)
-            }
-            let replaced = executeRoute(args: buildRouteArgs(verb: "add", destination: destination, gateway: gateway, isNetwork: isNetwork))
-            return (replaced.success, replaced.error)
-        }
-
-        helperLog.error("install \(destination, privacy: .public) failed: \(added.error ?? "unknown", privacy: .public)")
-        return (false, added.error)
-    }
-
-    /// True when the kernel already holds exactly this route, so installing it again would be a
-    /// pure no-op write. `route -n get` is a READ: it reports the route that *would* be used and
-    /// raises no route-change event, so asking is free in the sense that matters here.
-    ///
-    /// The `destination:` comparison is load-bearing, not defensive padding. For a host with NO
-    /// specific route, `route get` reports the DEFAULT route — and in Bypass mode the default
-    /// route's gateway IS the local gateway we are about to install through. Comparing gateways
-    /// alone would therefore report "already correct" for a route that does not exist, and we
-    /// would silently never install it: the bypass would break with no error anywhere. Requiring
-    /// `destination` to equal the host we asked about is what distinguishes "this exact route is
-    /// present" from "something else would carry this traffic".
-    ///
-    /// Network routes are handled too, by comparing BOTH `destination:` and `mask:`. Excluding them
-    /// (as the first cut of this check did) left VPN Only mode churning on every single apply: its
-    /// `0.0.0.0/1` + `128.0.0.0/1` catch-alls are network routes, so they were rewritten every time
-    /// — which is exactly the leak-critical mode where a coexisting VPN client reacting to our
-    /// route-change events does the most damage. `route -n get -net <cidr>` reports the network in
-    /// `destination:` and the netmask in `mask:`, and reports the DEFAULT route (`destination:
-    /// default`, `mask: default`) when no such network route exists — so the same "did it echo back
-    /// what I asked about" discriminator that protects the host path protects this one.
-    private func routeAlreadyCorrect(destination: String, gateway: String, isNetwork: Bool) -> Bool {
-        let args = isNetwork ? ["-n", "get", "-net", destination] : ["-n", "get", destination]
-        guard let output = routeOutput(args: args) else { return false }
-
-        var dest: String?
-        var mask: String?
-        var gw: String?
-        var iface: String?
-        var flags = ""
-        for rawLine in output.split(separator: "\n") {
-            let line = rawLine.trimmingCharacters(in: .whitespaces)
-            if line.hasPrefix("destination:") {
-                dest = String(line.dropFirst("destination:".count)).trimmingCharacters(in: .whitespaces)
-            } else if line.hasPrefix("mask:") {
-                mask = String(line.dropFirst("mask:".count)).trimmingCharacters(in: .whitespaces)
-            } else if line.hasPrefix("gateway:") {
-                gw = String(line.dropFirst("gateway:".count)).trimmingCharacters(in: .whitespaces)
-            } else if line.hasPrefix("interface:") {
-                iface = String(line.dropFirst("interface:".count)).trimmingCharacters(in: .whitespaces)
-            } else if line.hasPrefix("flags:") {
-                flags = String(line.dropFirst("flags:".count)).trimmingCharacters(in: .whitespaces)
-            }
-        }
-
-        // The route we matched must be a real, static entry of the KIND we are installing — not an
-        // ephemeral clone and not a wider route that merely covers this address.
-        //
-        // This is the subtle one. The default route carries PRCLONING, so macOS mints short-lived
-        // host routes to arbitrary destinations that inherit the parent's gateway. Such a clone
-        // echoes back `destination: <our exact IP>` with `gateway: <local gateway>` — and in Bypass
-        // mode the local gateway is precisely what we were about to install. Without this guard we
-        // would call that "already correct", skip the write, record the route as applied, and then
-        // watch the clone expire — leaving the destination silently on whatever the parent route
-        // says. No error, no log, no failed verification: exactly the silent bypass failure the
-        // destination check above exists to prevent.
-        guard !flags.contains("WASCLONED"),
-              !flags.contains("REJECT"),
-              !flags.contains("BLACKHOLE") else { return false }
-        if isNetwork {
-            guard !flags.contains("HOST") else { return false }
-        } else {
-            guard flags.contains("HOST") else { return false }
-        }
-
-        if isNetwork {
-            // `route get -net 10.0.0.0/8` echoes `destination: 10.0.0.0` + `mask: 255.0.0.0`, so the
-            // CIDR we were handed has to be split and the prefix expanded before comparing. BOTH must
-            // match: destination alone would treat 0.0.0.0/1 and a 0.0.0.0/8 as the same route.
-            guard let (network, prefix) = RouteCIDR.parse(destination),
-                  dest == network,
-                  mask == RouteCIDR.netmaskString(prefixLength: prefix)
-            else { return false }
-        } else {
-            // No route specific to this host -> it must be installed. (For a host with no route,
-            // `route get` reports the DEFAULT route, whose gateway in Bypass mode is the same local
-            // gateway we are about to install through — so this check, not the gateway one, is what
-            // stops us silently skipping a route that does not exist.)
-            guard dest == destination else { return false }
-        }
-
-        if gateway.hasPrefix("iface:") {
-            return iface == String(gateway.dropFirst(6))
-        }
-        return gw == gateway
-    }
-
-    /// Wait for `process`, but never longer than `timeout`. On expiry the process is terminated and
-    /// `false` is returned.
-    ///
-    /// Every route/hosts mutation runs on ONE serial queue (see `routeQueue`), so an unbounded
-    /// `waitUntilExit()` means a single wedged `/sbin/route` blocks every later add, remove, batch
-    /// and hosts update for the lifetime of the helper — with no watchdog and no recovery short of
-    /// restarting a root daemon. Bounding the wait keeps a stuck child from taking the pipeline
-    /// down with it; the caller sees an ordinary failure and can retry.
-    private func waitBounded(_ process: Process, timeout: TimeInterval = 10) -> Bool {
-        let done = DispatchSemaphore(value: 0)
-        DispatchQueue.global(qos: .userInitiated).async {
-            process.waitUntilExit()
-            done.signal()
-        }
-        if done.wait(timeout: .now() + timeout) == .timedOut {
-            helperLog.error("route command exceeded \(timeout, privacy: .public)s — terminating")
-            process.terminate()
-            _ = done.wait(timeout: .now() + 2)
-            return false
-        }
-        return true
-    }
-
-    /// Run `route` and capture stdout. Used only for read-only queries (`route -n get`).
-    private func routeOutput(args: [String]) -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/sbin/route")
-        process.arguments = args
-
-        let outPipe = Pipe()
-        process.standardOutput = outPipe
-        process.standardError = FileHandle.nullDevice
-
-        do {
-            try process.run()
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-            guard waitBounded(process), process.terminationStatus == 0 else { return nil }
-            return String(data: data, encoding: .utf8)
-        } catch {
-            return nil
-        }
-    }
-
-    private func executeRoute(args: [String]) -> (success: Bool, error: String?) {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/sbin/route")
-        process.arguments = args
-        
-        let errorPipe = Pipe()
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = errorPipe
-        
-        do {
-            try process.run()
-            guard waitBounded(process) else {
-                return (false, "route command timed out")
-            }
-
-            if process.terminationStatus == 0 {
+        if err == EEXIST {
+            // A route landed between the snapshot and the add — converge with a change.
+            err = routeSocketPerform(type: RTM_CHANGE, spec: spec)
+            if err == nil {
+                helperLog.info("install \(destination, privacy: .public): raced, changed in place")
                 return (true, nil)
-            } else {
-                let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-                let errorString = String(data: errorData, encoding: .utf8) ?? "Unknown error"
-                return (false, errorString.trimmingCharacters(in: .whitespacesAndNewlines))
             }
-        } catch {
-            return (false, error.localizedDescription)
         }
+        let message = errnoString(err ?? EINVAL)
+        helperLog.error("install \(destination, privacy: .public) failed: \(message, privacy: .public)")
+        return (false, message)
     }
-    
+
+    /// Remove one route. "Not in table" (ESRCH) is SUCCESS — the goal state is "absent", and
+    /// treating an already-gone route as a failure made teardown retain phantom records.
+    private func deleteRoute(destination: String) -> (success: Bool, error: String?) {
+        let isNetwork = destination.contains("/") && !destination.hasSuffix("/32")
+        let spec = RouteKernel.Spec(destination: destination, gateway: .address("0.0.0.0"),
+                                    isNetwork: isNetwork)
+        let err = routeSocketPerform(type: RTM_DELETE, spec: spec)
+        if err == nil {
+            helperLog.info("delete \(destination, privacy: .public): removed")
+            return (true, nil)
+        }
+        if err == ESRCH {
+            helperLog.info("delete \(destination, privacy: .public): already absent")
+            return (true, nil)
+        }
+        let message = errnoString(err!)
+        helperLog.error("delete \(destination, privacy: .public) failed: \(message, privacy: .public)")
+        return (false, message)
+    }
+
     // MARK: - Hosts File Management
     
     func updateHostsFile(entries: [[String: String]], withReply reply: @escaping (Bool, String?) -> Void) {
@@ -570,18 +522,6 @@ class HelperTool: NSObject, HelperProtocol {
 
     /// Build `route(8)` arguments for `verb` ("add" or "change"). Both take an identical argument
     /// shape, so `installRoute` can try an in-place change before falling back to an add.
-    private func buildRouteArgs(verb: String, destination: String, gateway: String, isNetwork: Bool) -> [String] {
-        var args = ["-n", verb]
-        args.append(isNetwork ? "-net" : "-host")
-        args.append(destination)
-        if gateway.hasPrefix("iface:") {
-            args.append(contentsOf: ["-interface", String(gateway.dropFirst(6))])
-        } else {
-            args.append(gateway)
-        }
-        return args
-    }
-
     private func isValidIP(_ string: String) -> Bool {
         let parts = string.components(separatedBy: ".")
         guard parts.count == 4 else { return false }

--- a/Helper/Info.plist
+++ b/Helper/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleName</key>
 	<string>VPNBypassHelper</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.11.0</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>11</string>
 	<key>SMAuthorizedClients</key>

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ build-helper:
 		-target arm64-apple-macos13.0 \
 		-o $(HELPER_BUILD_DIR)/$(HELPER_ID)-arm64 \
 		Sources/VPNBypassCore/HelperProtocol.swift \
+		Sources/VPNBypassCore/RouteKernel.swift \
 		Helper/HelperTool.swift \
 		Helper/main.swift
 	@swiftc -O \
@@ -28,6 +29,7 @@ build-helper:
 		-target x86_64-apple-macos13.0 \
 		-o $(HELPER_BUILD_DIR)/$(HELPER_ID)-x86_64 \
 		Sources/VPNBypassCore/HelperProtocol.swift \
+		Sources/VPNBypassCore/RouteKernel.swift \
 		Helper/HelperTool.swift \
 		Helper/main.swift
 	@lipo -create \

--- a/Sources/VPNBypassCore/HelperProtocol.swift
+++ b/Sources/VPNBypassCore/HelperProtocol.swift
@@ -112,7 +112,7 @@ struct HelperConstants {
     // replaces only as a last resort. Route/hosts mutations are also serialised across XPC
     // connections (concurrent handlers were producing simultaneous /sbin/route processes), and the
     // helper finally emits os_log records. Bumped from 1.8.0 so installed helpers pick this up.
-    static let helperVersion = "1.11.0"
+    static let helperVersion = "2.0.0"
     static let bundleID = "com.geiserx.vpnbypass.helper"
     static let hostMarkerStart = "# VPN-BYPASS-MANAGED - START"
     static let hostMarkerEnd = "# VPN-BYPASS-MANAGED - END"

--- a/Sources/VPNBypassCore/RouteKernel.swift
+++ b/Sources/VPNBypassCore/RouteKernel.swift
@@ -1,0 +1,315 @@
+// RouteKernel.swift
+// Pure construction and parsing of routing-socket (PF_ROUTE) messages, shared between the app
+// and the privileged helper, and unit-tested from the app test target.
+//
+// WHY THIS EXISTS — the traced root cause of the VPN instability this app used to trigger was
+// never the route *writes* themselves (the corporate client debounces those and demonstrably
+// tolerates hundreds); it was SUBPROCESS CONTENTION: every `/sbin/route` invocation is a
+// fork+exec that opens its own routing socket and blocks with no timeout. Stacked invocations
+// starved other processes' route operations — including the VPN client's own periodic gateway
+// route *read*, whose timeout the client misreads as "my gateway route was removed" and tears
+// the tunnel down. Writing rt_msghdr structs to one owned socket makes that starvation
+// structurally impossible: no forks, one in-flight request, errno straight from write(2).
+//
+// Layout notes that differ from other BSDs (the classic porting traps):
+//   - sockaddr alignment inside a routing message is FOUR bytes on macOS, not sizeof(long).
+//   - the netmask sockaddr is TRIMMED: sa_len covers only up to the last non-zero byte
+//     (255.255.255.0 → sa_len 7), and host routes omit the netmask entirely and set RTF_HOST.
+//   - sockaddrs follow the header positionally in RTA bit order: DST, GATEWAY, NETMASK.
+// All struct layouts and constants come from the SDK via `import Darwin` — nothing is
+// hand-computed.
+
+import Foundation
+import Darwin
+
+public enum RouteKernel {
+
+    // MARK: - Specs
+
+    /// Where a route sends traffic.
+    public enum Gateway: Equatable, Sendable {
+        /// Next hop by IPv4 address ("192.168.1.1").
+        case address(String)
+        /// Direct interface route (`route add -interface`), by kernel interface index.
+        case interfaceIndex(UInt16)
+    }
+
+    /// One route to install or remove, already validated by the caller.
+    public struct Spec: Equatable, Sendable {
+        public let destination: String   // "1.2.3.4" or "10.0.0.0/8" when isNetwork
+        public let gateway: Gateway
+        public let isNetwork: Bool
+
+        public init(destination: String, gateway: Gateway, isNetwork: Bool) {
+            self.destination = destination
+            self.gateway = gateway
+            self.isNetwork = isNetwork
+        }
+    }
+
+    // MARK: - Message construction
+
+    /// Routing-socket sockaddr alignment on macOS. Four bytes — NOT sizeof(long); copying the
+    /// 8-byte ROUNDUP from FreeBSD/OpenBSD examples silently misaligns every sockaddr.
+    public static func roundup(_ n: Int) -> Int {
+        n > 0 ? (n + 3) & ~3 : 4
+    }
+
+    /// Builds a complete RTM_ADD / RTM_DELETE / RTM_CHANGE message for `spec`.
+    ///
+    /// Every route this app creates is tagged `RTF_PROTO1` — the ownership marker that lets a
+    /// startup sweep identify OUR routes in a plain table dump with no journal, and lets any
+    /// third party attribute them. (`RTF_PROTO3` must never be used: it is the kernel's own
+    /// `RTPRF_OURS` garbage-collection marker and inviting the kernel to expire our routes.)
+    ///
+    /// Returns nil only for an unparseable destination/gateway (caller validated, so this is
+    /// defense in depth).
+    public static func message(type: Int32, seq: Int32, spec: Spec) -> Data? {
+        let (dstIP, prefix): (UInt32, Int?)
+        if spec.isNetwork {
+            guard let cidr = RouteCIDR.parse(spec.destination),
+                  let net = ipv4ToUInt32(cidr.network) else { return nil }
+            (dstIP, prefix) = (net, cidr.prefixLength)
+        } else {
+            // Accept an accidental "/32" spelling of a host.
+            let bare = spec.destination.hasSuffix("/32")
+                ? String(spec.destination.dropLast(3)) : spec.destination
+            guard let host = ipv4ToUInt32(bare) else { return nil }
+            (dstIP, prefix) = (host, nil)
+        }
+
+        var flags: Int32 = RTF_UP | RTF_STATIC | RTF_PROTO1
+        var addrs: Int32 = RTA_DST | RTA_GATEWAY
+        var gatewayData: Data
+
+        switch spec.gateway {
+        case .address(let ip):
+            guard let gw = ipv4ToUInt32(ip) else { return nil }
+            flags |= RTF_GATEWAY
+            gatewayData = sockaddrInData(gw)
+        case .interfaceIndex(let index):
+            // Direct interface route: gateway is an AF_LINK sockaddr naming the interface,
+            // and RTF_GATEWAY must NOT be set.
+            gatewayData = sockaddrDLData(index: index)
+        }
+
+        var maskData: Data? = nil
+        if let prefix {
+            addrs |= RTA_NETMASK
+            maskData = trimmedMaskData(prefix: prefix)
+        } else {
+            flags |= RTF_HOST
+        }
+
+        // RTM_DELETE identifies the route by destination (+mask); a gateway is unnecessary and
+        // a mismatched one can make the delete miss.
+        if type == RTM_DELETE {
+            addrs &= ~RTA_GATEWAY
+            gatewayData = Data()
+        }
+
+        var hdr = rt_msghdr()
+        hdr.rtm_version = u_char(RTM_VERSION)
+        hdr.rtm_type = u_char(type)
+        hdr.rtm_flags = flags
+        hdr.rtm_addrs = addrs
+        hdr.rtm_seq = seq
+        // rtm_pid is stamped by the kernel; rtm_index only matters for RTF_IFSCOPE (unused here).
+
+        var body = Data()
+        body.append(paddedSockaddr(sockaddrInData(dstIP)))
+        if !gatewayData.isEmpty { body.append(paddedSockaddr(gatewayData)) }
+        if let maskData { body.append(paddedSockaddr(maskData)) }
+
+        hdr.rtm_msglen = u_short(MemoryLayout<rt_msghdr>.size + body.count)
+        var out = withUnsafeBytes(of: &hdr) { Data($0) }
+        out.append(body)
+        return out
+    }
+
+    // MARK: - Table parsing (NET_RT_DUMP)
+
+    /// One route as read back from the kernel.
+    public struct KernelRoute: Equatable, Sendable {
+        public let destination: UInt32       // network byte order host value (big-endian semantics)
+        public let prefix: Int?              // nil = host route
+        public let gatewayAddress: UInt32?   // set when the gateway is an AF_INET next hop
+        public let gatewayInterfaceIndex: UInt16?  // set when the gateway is AF_LINK
+        public let flags: Int32
+
+        public var isOurs: Bool { flags & RTF_PROTO1 != 0 }
+        public var isHost: Bool { prefix == nil }
+
+        /// Dotted-quad plus optional /prefix, matching the app's destination strings.
+        public var destinationString: String {
+            let d = dotted(destination)
+            if let prefix { return "\(d)/\(prefix)" }
+            return d
+        }
+    }
+
+    /// Parses the raw bytes of a `sysctl NET_RT_DUMP` (AF_INET) into routes.
+    ///
+    /// This read is SILENT — it broadcasts nothing to routing-socket listeners and forks
+    /// nothing, unlike `route -n get`, which does both once per destination. One dump replaces
+    /// hundreds of per-route reads.
+    public static func parseTable(_ data: Data) -> [KernelRoute] {
+        var routes: [KernelRoute] = []
+        var offset = 0
+        let hdrSize = MemoryLayout<rt_msghdr>.size
+
+        while offset + hdrSize <= data.count {
+            let hdr: rt_msghdr = data.withUnsafeBytes { raw in
+                raw.loadUnaligned(fromByteOffset: offset, as: rt_msghdr.self)
+            }
+            let msglen = Int(hdr.rtm_msglen)
+            guard msglen >= hdrSize, offset + msglen <= data.count else { break }
+            defer { offset += msglen }
+
+            guard hdr.rtm_version == u_char(RTM_VERSION) else { continue }
+
+            var cursor = offset + hdrSize
+            let end = offset + msglen
+            var dst: UInt32? = nil
+            var gwAddr: UInt32? = nil
+            var gwIndex: UInt16? = nil
+            var maskPrefix: Int? = nil
+            var sawMask = false
+
+            // Sockaddrs are positional in RTA bit order.
+            for bit in 0..<31 {
+                let rta = Int32(1) << bit
+                guard hdr.rtm_addrs & rta != 0 else { continue }
+                guard cursor < end else { break }
+                let saLen = Int(data[cursor])
+                let family = cursor + 1 < end ? data[cursor + 1] : 0
+                let advance = roundup(saLen)
+
+                switch rta {
+                case RTA_DST:
+                    dst = readIPv4(data, at: cursor, saLen: saLen)
+                case RTA_GATEWAY:
+                    if family == u_char(AF_INET) {
+                        gwAddr = readIPv4(data, at: cursor, saLen: saLen)
+                    } else if family == u_char(AF_LINK), saLen >= 4 {
+                        // sockaddr_dl: sdl_index at offset 2 (little-endian in memory).
+                        gwIndex = UInt16(data[cursor + 2]) | (UInt16(data[cursor + 3]) << 8)
+                    }
+                case RTA_NETMASK:
+                    sawMask = true
+                    maskPrefix = prefixFromTrimmedMask(data, at: cursor, saLen: saLen)
+                default:
+                    break
+                }
+                cursor += advance
+            }
+
+            guard let dst else { continue }
+            let isHost = hdr.rtm_flags & RTF_HOST != 0 || !sawMask
+            routes.append(KernelRoute(
+                destination: dst,
+                prefix: isHost ? nil : maskPrefix,
+                gatewayAddress: gwAddr,
+                gatewayInterfaceIndex: gwIndex,
+                flags: hdr.rtm_flags
+            ))
+        }
+        return routes
+    }
+
+    /// Reads the live IPv4 routing table via sysctl — silent and unprivileged.
+    public static func currentTable() -> [KernelRoute]? {
+        var mib: [Int32] = [CTL_NET, PF_ROUTE, 0, AF_INET, NET_RT_DUMP, 0]
+        var needed = 0
+        guard sysctl(&mib, u_int(mib.count), nil, &needed, nil, 0) == 0, needed > 0 else { return nil }
+        // The table can grow between the size probe and the read — retry with headroom.
+        for slack in [0, needed / 2, needed] {
+            var size = needed + slack
+            var buf = Data(count: size)
+            let ok = buf.withUnsafeMutableBytes { raw -> Bool in
+                sysctl(&mib, u_int(mib.count), raw.baseAddress, &size, nil, 0) == 0
+            }
+            if ok {
+                return parseTable(buf.prefix(size))
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Sockaddr builders (internal for tests)
+
+    static func sockaddrInData(_ ip: UInt32) -> Data {
+        var sin = sockaddr_in()
+        sin.sin_len = u_char(MemoryLayout<sockaddr_in>.size)
+        sin.sin_family = sa_family_t(AF_INET)
+        sin.sin_addr = in_addr(s_addr: ip.bigEndian)
+        return withUnsafeBytes(of: &sin) { Data($0) }
+    }
+
+    /// The trimmed netmask sockaddr: sa_len reaches only the last non-zero byte.
+    /// 255.255.255.0 → sa_len 7 · 255.255.0.0 → 6 · 255.0.0.0 → 5 · 128.0.0.0 → 5.
+    static func trimmedMaskData(prefix: Int) -> Data {
+        let mask: UInt32 = prefix == 0 ? 0 : ~UInt32(0) << (32 - prefix)
+        var bytes: [UInt8] = [0, u_char(AF_INET), 0, 0,
+                              UInt8((mask >> 24) & 0xff), UInt8((mask >> 16) & 0xff),
+                              UInt8((mask >> 8) & 0xff), UInt8(mask & 0xff)]
+        var last = 0
+        for i in 1..<bytes.count where bytes[i] != 0 { last = i }
+        let saLen = last + 1
+        bytes[0] = UInt8(saLen)
+        return Data(bytes.prefix(saLen))
+    }
+
+    static func sockaddrDLData(index: UInt16) -> Data {
+        var sdl = sockaddr_dl()
+        sdl.sdl_len = u_char(MemoryLayout<sockaddr_dl>.size)
+        sdl.sdl_family = sa_family_t(AF_LINK)
+        sdl.sdl_index = index
+        return withUnsafeBytes(of: &sdl) { Data($0) }
+    }
+
+    static func paddedSockaddr(_ sa: Data) -> Data {
+        let target = roundup(sa.count)
+        guard sa.count < target else { return sa }
+        return sa + Data(count: target - sa.count)
+    }
+
+    // MARK: - Small helpers
+
+    static func ipv4ToUInt32(_ s: String) -> UInt32? {
+        let parts = s.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 4 else { return nil }
+        var value: UInt32 = 0
+        for p in parts {
+            guard let b = UInt8(p) else { return nil }
+            value = (value << 8) | UInt32(b)
+        }
+        return value
+    }
+
+    static func dotted(_ ip: UInt32) -> String {
+        "\((ip >> 24) & 0xff).\((ip >> 16) & 0xff).\((ip >> 8) & 0xff).\(ip & 0xff)"
+    }
+
+    static func readIPv4(_ data: Data, at cursor: Int, saLen: Int) -> UInt32? {
+        // sockaddr_in: sin_addr at offset 4. A trimmed sockaddr may end early — missing
+        // trailing bytes are zero by definition.
+        var value: UInt32 = 0
+        for i in 0..<4 {
+            let idx = cursor + 4 + i
+            let byte: UInt8 = (i + 4) < saLen && idx < data.count ? data[idx] : 0
+            value = (value << 8) | UInt32(byte)
+        }
+        return value
+    }
+
+    static func prefixFromTrimmedMask(_ data: Data, at cursor: Int, saLen: Int) -> Int {
+        var mask: UInt32 = 0
+        for i in 0..<4 {
+            let idx = cursor + 4 + i
+            let byte: UInt8 = (i + 4) < saLen && idx < data.count ? data[idx] : 0
+            mask = (mask << 8) | UInt32(byte)
+        }
+        return mask.nonzeroBitCount
+    }
+}

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -1151,6 +1151,10 @@ final class RouteManager: ObservableObject {
             }
         } else if !isVPNConnected {
             log(.info, "No VPN connection detected")
+            // With no VPN there is nothing this app should be routing — remove ANY tagged
+            // leftovers from a crashed/killed previous run, catch-alls included. This is the
+            // path that heals the "app off, public IP still wrong" report class on its own.
+            await startupSweepIfNeeded(desired: [])
             isLoading = false
         } else if localGateway == nil {
             log(.error, "Could not detect local gateway")
@@ -1898,6 +1902,10 @@ final class RouteManager: ObservableObject {
             build.routesToAdd.map { ($0.destination, $0.gateway, $0.isNetwork, $0.source) }
         let allSourceEntries: [(destination: String, gateway: String, source: String)] =
             build.allSourceEntries.map { ($0.destination, $0.gateway, $0.source) }
+
+        // Crash recovery first: clear tagged leftovers a previous run stranded, keeping what
+        // this apply wants (those become zero-event no-ops in the reconciling batch below).
+        await startupSweepIfNeeded(desired: routesToAdd.map { $0.destination })
 
         log(.info, "Applying \(routesToAdd.count) routes from cache (\(isInverse ? "VPN Only" : "Bypass") mode)...")
 
@@ -3691,6 +3699,35 @@ final class RouteManager: ObservableObject {
     
     // MARK: - Private Methods
     
+    /// One sweep per launch: has the orphan sweep already run this session?
+    private var didStartupSweep = false
+
+    /// Which table entries are OUR orphans: tagged RTF_PROTO1 (only this app sets it) yet not
+    /// wanted by the current session. Pure so it can be unit-tested against synthetic tables.
+    nonisolated static func orphanedDestinations(
+        table: [RouteKernel.KernelRoute], desired: Set<String>
+    ) -> [String] {
+        table.filter { $0.isOurs }.map(\.destinationString).filter { !desired.contains($0) }
+    }
+
+    /// Startup crash/unclean-quit recovery — the permanent fix for the issue #67 class.
+    ///
+    /// Every route this app installs is tagged RTF_PROTO1 in the kernel, so a plain silent
+    /// table dump identifies ours with no journal and no prior state ("no other state needs to
+    /// be instantiated before this runs" — the property that makes this recovery reliable).
+    /// Anything tagged but not wanted by THIS session — including VPN Only catch-alls stranded
+    /// by a kill — is removed before the first apply. Wanted routes are left in place: the
+    /// snapshot-reconciling batch add makes them zero-event no-ops.
+    func startupSweepIfNeeded(desired: [String]) async {
+        guard !didStartupSweep else { return }
+        didStartupSweep = true
+        guard let table = RouteKernel.currentTable() else { return }
+        let orphans = Self.orphanedDestinations(table: table, desired: Set(desired))
+        guard !orphans.isEmpty else { return }
+        log(.warning, "Startup sweep: removing \(orphans.count) route(s) left by a previous run")
+        _ = await removeRoutesBatchVia(orphans)
+    }
+
     /// The only sanctioned way to batch-add routes to the kernel. Records destinations as
     /// pending BEFORE the write (so teardown can always find them) and refuses outright once
     /// shutdown has begun (so nothing lands mid-teardown).
@@ -3700,6 +3737,18 @@ final class RouteManager: ObservableObject {
         guard !isShuttingDown else {
             log(.warning, "Refusing batch add of \(routes.count) route(s): shutdown in progress")
             return (0, routes.count, routes.map { $0.destination }, "shutdown in progress")
+        }
+        // Never touch the route to the VPN's own gateway. Its client keeps the tunnel alive by
+        // reaching that address via the PHYSICAL interface; vendor documentation describes
+        // connect-then-flap-within-a-minute when that stops being true.
+        var routes = routes
+        if let gw = vpnGateway, !gw.hasPrefix("iface:") {
+            let protected = routes.filter { $0.destination == gw || $0.destination == gw + "/32" }
+            if !protected.isEmpty {
+                log(.warning, "Refusing \(protected.count) route(s) targeting the VPN gateway \(gw) — protected")
+                routes.removeAll { $0.destination == gw || $0.destination == gw + "/32" }
+                if routes.isEmpty { return (0, protected.count, protected.map { $0.destination }, "protected: VPN gateway") }
+            }
         }
         pendingKernelAdds.formUnion(routes.map { $0.destination })
         let result = await HelperManager.shared.addRoutesBatch(routes: routes)

--- a/Tests/VPNBypassTests/RouteKernelTests.swift
+++ b/Tests/VPNBypassTests/RouteKernelTests.swift
@@ -1,0 +1,162 @@
+// RouteKernelTests.swift
+// Byte-level coverage for routing-socket message construction and table parsing.
+//
+// These bytes go straight into the kernel via write(2) on a PF_ROUTE socket — a layout mistake
+// doesn't error, it creates the WRONG route (or a route the kernel can't match for deletion).
+// The two macOS-specific traps under test, both classic porting bugs:
+//   - sockaddr alignment is FOUR bytes (FreeBSD/OpenBSD examples use 8 and silently misalign)
+//   - the netmask sockaddr is TRIMMED (sa_len stops at the last non-zero byte)
+
+import XCTest
+import Darwin
+@testable import VPNBypassCore
+
+final class RouteKernelTests: XCTestCase {
+
+    private let hdrSize = MemoryLayout<rt_msghdr>.size  // 92 on macOS
+
+    private func header(of data: Data) -> rt_msghdr {
+        data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 0, as: rt_msghdr.self) }
+    }
+
+    // MARK: - Alignment
+
+    func testRoundupIsFourByte() {
+        XCTAssertEqual(RouteKernel.roundup(0), 4)
+        XCTAssertEqual(RouteKernel.roundup(1), 4)
+        XCTAssertEqual(RouteKernel.roundup(4), 4)
+        XCTAssertEqual(RouteKernel.roundup(5), 8)
+        XCTAssertEqual(RouteKernel.roundup(7), 8)
+        XCTAssertEqual(RouteKernel.roundup(16), 16)
+        XCTAssertEqual(RouteKernel.roundup(20), 20)
+    }
+
+    // MARK: - Trimmed netmask
+
+    func testNetmaskIsTrimmedToLastNonzeroByte() {
+        XCTAssertEqual(RouteKernel.trimmedMaskData(prefix: 24).count, 7)  // 255.255.255.0
+        XCTAssertEqual(RouteKernel.trimmedMaskData(prefix: 16).count, 6)  // 255.255.0.0
+        XCTAssertEqual(RouteKernel.trimmedMaskData(prefix: 8).count, 5)   // 255.0.0.0
+        XCTAssertEqual(RouteKernel.trimmedMaskData(prefix: 1).count, 5)   // 128.0.0.0
+        XCTAssertEqual(RouteKernel.trimmedMaskData(prefix: 10).count, 6)  // 255.192.0.0
+        XCTAssertEqual(RouteKernel.trimmedMaskData(prefix: 32).count, 8)  // 255.255.255.255
+        // sa_len byte must equal the data length
+        for p in [1, 8, 10, 16, 24, 32] {
+            let d = RouteKernel.trimmedMaskData(prefix: p)
+            XCTAssertEqual(Int(d[0]), d.count, "sa_len must match trimmed length for /\(p)")
+        }
+    }
+
+    // MARK: - Message construction
+
+    func testHostAddMessageLayout() throws {
+        let spec = RouteKernel.Spec(destination: "203.0.113.7",
+                                    gateway: .address("192.168.1.1"), isNetwork: false)
+        let msg = try XCTUnwrap(RouteKernel.message(type: RTM_ADD, seq: 42, spec: spec))
+        let hdr = header(of: msg)
+        XCTAssertEqual(Int(hdr.rtm_msglen), msg.count)
+        XCTAssertEqual(msg.count, hdrSize + 16 + 16, "header + dst sockaddr_in + gw sockaddr_in")
+        XCTAssertEqual(Int(hdr.rtm_version), Int(RTM_VERSION))
+        XCTAssertEqual(Int(hdr.rtm_type), Int(RTM_ADD))
+        XCTAssertEqual(hdr.rtm_seq, 42)
+        XCTAssertEqual(hdr.rtm_addrs, RTA_DST | RTA_GATEWAY)
+        for flag in [RTF_UP, RTF_STATIC, RTF_HOST, RTF_GATEWAY, RTF_PROTO1] {
+            XCTAssertNotEqual(hdr.rtm_flags & flag, 0, "missing flag 0x\(String(flag, radix: 16))")
+        }
+        XCTAssertEqual(hdr.rtm_flags & RTF_PROTO3, 0, "PROTO3 is the kernel's GC marker — never set")
+    }
+
+    func testNetworkAddCarriesTrimmedPaddedMask() throws {
+        let spec = RouteKernel.Spec(destination: "10.20.0.0/16",
+                                    gateway: .address("192.168.1.1"), isNetwork: true)
+        let msg = try XCTUnwrap(RouteKernel.message(type: RTM_ADD, seq: 1, spec: spec))
+        let hdr = header(of: msg)
+        // /16 mask trims to sa_len 6, padded to 8 on the wire.
+        XCTAssertEqual(msg.count, hdrSize + 16 + 16 + 8)
+        XCTAssertEqual(hdr.rtm_addrs, RTA_DST | RTA_GATEWAY | RTA_NETMASK)
+        XCTAssertEqual(hdr.rtm_flags & RTF_HOST, 0, "a network route must not carry RTF_HOST")
+        XCTAssertEqual(Int(msg[hdrSize + 32]), 6, "mask sa_len must be the trimmed 6, not 16")
+    }
+
+    func testDeleteOmitsGateway() throws {
+        let spec = RouteKernel.Spec(destination: "203.0.113.7",
+                                    gateway: .address("192.168.1.1"), isNetwork: false)
+        let msg = try XCTUnwrap(RouteKernel.message(type: RTM_DELETE, seq: 9, spec: spec))
+        let hdr = header(of: msg)
+        XCTAssertEqual(hdr.rtm_addrs, RTA_DST, "delete identifies by destination — a stale gateway would make it miss")
+        XCTAssertEqual(msg.count, hdrSize + 16)
+    }
+
+    func testInterfaceGatewayIsAFLinkWithoutRTFGateway() throws {
+        let spec = RouteKernel.Spec(destination: "203.0.113.7",
+                                    gateway: .interfaceIndex(7), isNetwork: false)
+        let msg = try XCTUnwrap(RouteKernel.message(type: RTM_ADD, seq: 3, spec: spec))
+        let hdr = header(of: msg)
+        XCTAssertEqual(hdr.rtm_flags & RTF_GATEWAY, 0,
+                       "an interface route must NOT set RTF_GATEWAY")
+        XCTAssertEqual(Int(msg[hdrSize + 16 + 1]), Int(AF_LINK), "gateway family must be AF_LINK")
+        XCTAssertEqual(msg.count, hdrSize + 16 + 20)
+    }
+
+    func testUnparseableInputsReturnNil() {
+        XCTAssertNil(RouteKernel.message(type: RTM_ADD, seq: 1, spec:
+            .init(destination: "not-an-ip", gateway: .address("192.168.1.1"), isNetwork: false)))
+        XCTAssertNil(RouteKernel.message(type: RTM_ADD, seq: 1, spec:
+            .init(destination: "203.0.113.7", gateway: .address("bogus"), isNetwork: false)))
+    }
+
+    // MARK: - Roundtrip through the parser
+
+    /// What we write must be exactly what we can read back — the reconcile diff depends on it.
+    func testMessageParsesBackIdentically() throws {
+        let host = try XCTUnwrap(RouteKernel.message(type: RTM_ADD, seq: 1, spec:
+            .init(destination: "203.0.113.7", gateway: .address("192.168.1.1"), isNetwork: false)))
+        let net = try XCTUnwrap(RouteKernel.message(type: RTM_ADD, seq: 2, spec:
+            .init(destination: "10.20.0.0/16", gateway: .address("192.168.1.1"), isNetwork: true)))
+        let iface = try XCTUnwrap(RouteKernel.message(type: RTM_ADD, seq: 3, spec:
+            .init(destination: "198.51.100.9", gateway: .interfaceIndex(12), isNetwork: false)))
+
+        let parsed = RouteKernel.parseTable(host + net + iface)
+        XCTAssertEqual(parsed.count, 3)
+
+        XCTAssertEqual(parsed[0].destinationString, "203.0.113.7")
+        XCTAssertTrue(parsed[0].isHost)
+        XCTAssertEqual(parsed[0].gatewayAddress.map(RouteKernel.dotted), "192.168.1.1")
+        XCTAssertTrue(parsed[0].isOurs, "our PROTO1 tag must survive the roundtrip")
+
+        XCTAssertEqual(parsed[1].destinationString, "10.20.0.0/16")
+        XCTAssertFalse(parsed[1].isHost)
+
+        XCTAssertEqual(parsed[2].gatewayInterfaceIndex, 12)
+    }
+
+    func testParserSkipsGarbageWithoutCrashing() {
+        XCTAssertTrue(RouteKernel.parseTable(Data()).isEmpty)
+        XCTAssertTrue(RouteKernel.parseTable(Data(repeating: 0, count: 50)).isEmpty)
+        // A header claiming a length beyond the buffer must stop the walk, not crash it.
+        var truncated = RouteKernel.message(type: RTM_ADD, seq: 1, spec:
+            .init(destination: "203.0.113.7", gateway: .address("192.168.1.1"), isNetwork: false))!
+        truncated.removeLast(10)
+        XCTAssertTrue(RouteKernel.parseTable(truncated).isEmpty)
+    }
+
+    // MARK: - Live table (silent read)
+
+    /// The silent sysctl read must work unprivileged — it is what replaces hundreds of
+    /// event-emitting, process-forking `route -n get` calls.
+    func testCurrentTableReadsLiveRoutesSilently() throws {
+        let table = try XCTUnwrap(RouteKernel.currentTable(), "NET_RT_DUMP must be readable unprivileged")
+        XCTAssertFalse(table.isEmpty, "a live machine always has IPv4 routes")
+        XCTAssertTrue(table.contains { $0.gatewayAddress != nil || $0.gatewayInterfaceIndex != nil })
+    }
+
+    // MARK: - Helpers
+
+    func testIPv4Conversions() {
+        XCTAssertEqual(RouteKernel.ipv4ToUInt32("1.2.3.4"), 0x01020304)
+        XCTAssertEqual(RouteKernel.dotted(0x01020304), "1.2.3.4")
+        XCTAssertNil(RouteKernel.ipv4ToUInt32("1.2.3"))
+        XCTAssertNil(RouteKernel.ipv4ToUInt32("1.2.3.256"))
+        XCTAssertNil(RouteKernel.ipv4ToUInt32(""))
+    }
+}

--- a/Tests/VPNBypassTests/StartupSweepTests.swift
+++ b/Tests/VPNBypassTests/StartupSweepTests.swift
@@ -1,0 +1,84 @@
+// StartupSweepTests.swift
+// Coverage for crash/unclean-quit recovery via ownership-tagged routes — the permanent fix for
+// the issue #67 class ("app on/off but my public IP is my real one").
+//
+// Every route this app installs is tagged RTF_PROTO1 in the kernel; only this app sets that
+// flag. A startup sweep reads one silent table dump and removes tagged entries the current
+// session does not want — needing NO journal and NO surviving in-memory state, which is exactly
+// what a kill -9 or a pre-fix quit race leaves behind. Routes the session DOES want are kept:
+// the snapshot-reconciling batch add turns them into zero-event no-ops.
+
+import XCTest
+import Darwin
+@testable import VPNBypassCore
+
+@MainActor
+final class StartupSweepTests: XCTestCase {
+
+    private func kr(_ dest: UInt32, prefix: Int? = nil, ours: Bool, gw: UInt32 = 0xC0A80101) -> RouteKernel.KernelRoute {
+        RouteKernel.KernelRoute(destination: dest, prefix: prefix, gatewayAddress: gw,
+                                gatewayInterfaceIndex: nil,
+                                flags: RTF_UP | RTF_STATIC | (ours ? RTF_PROTO1 : 0))
+    }
+
+    /// The Tetonne scenario: stranded VPN Only catch-alls (0.0.0.0/1 + 128.0.0.0/1) surviving a
+    /// kill, with the next session wanting none of them. Both must be identified for removal —
+    /// and a foreign route to the same shape of destination must NOT be.
+    func testStrandedCatchAllsAreOrphansButForeignRoutesAreNot() {
+        let table = [
+            kr(0x00000000, prefix: 1, ours: true),    // 0.0.0.0/1    — ours, stranded
+            kr(0x80000000, prefix: 1, ours: true),    // 128.0.0.0/1  — ours, stranded
+            kr(0xCB007107, ours: false),              // 203.0.113.7  — someone else's host route
+            kr(0x0A000000, prefix: 8, ours: false),   // 10.0.0.0/8   — the VPN's own
+        ]
+        let orphans = RouteManager.orphanedDestinations(table: table, desired: [])
+        XCTAssertEqual(Set(orphans), ["0.0.0.0/1", "128.0.0.0/1"],
+                       "ONLY tagged routes may be swept — never other software's")
+    }
+
+    /// Wanted routes survive the sweep so the reconciling apply can no-op them (zero events),
+    /// while unwanted tagged leftovers still go.
+    func testDesiredTaggedRoutesAreKept() {
+        let table = [
+            kr(0xCB007101, ours: true),  // 203.0.113.1 — still wanted
+            kr(0xCB007102, ours: true),  // 203.0.113.2 — no longer in config
+        ]
+        let orphans = RouteManager.orphanedDestinations(table: table, desired: ["203.0.113.1"])
+        XCTAssertEqual(orphans, ["203.0.113.2"])
+    }
+
+    func testEmptyTableAndUntaggedTableYieldNothing() {
+        XCTAssertTrue(RouteManager.orphanedDestinations(table: [], desired: []).isEmpty)
+        let foreign = [kr(0xCB007107, ours: false)]
+        XCTAssertTrue(RouteManager.orphanedDestinations(table: foreign, desired: []).isEmpty)
+    }
+
+    /// The sweep must run at most once per launch — re-running on every status pass would
+    /// re-scan the table endlessly for no benefit.
+    func testSweepRunsOncePerSession() async {
+        let rm = RouteManager.shared
+        await rm.startupSweepIfNeeded(desired: [])
+        // Second call must return immediately (same session) — observable only as "does not
+        // throw/hang"; the guard flag is private by design.
+        await rm.startupSweepIfNeeded(desired: [])
+    }
+
+    // MARK: - VPN gateway protection (P1.5)
+
+    /// A batch containing the VPN's own gateway must refuse exactly that destination and let the
+    /// rest through — disturbing the gateway route is the vendor-documented fast teardown.
+    func testBatchAddRefusesVPNGatewayDestination() async {
+        let rm = RouteManager.shared
+        let savedGW = rm.vpnGateway
+        defer { rm.vpnGateway = savedGW }
+        rm.vpnGateway = "198.51.100.44"
+
+        let result = await rm.addRoutesBatchTracked(routes: [
+            (destination: "198.51.100.44", gateway: "192.168.1.1", isNetwork: false),
+        ])
+        XCTAssertEqual(result.failureCount, 1)
+        XCTAssertEqual(result.failedDestinations, ["198.51.100.44"])
+        XCTAssertEqual(result.error, "protected: VPN gateway")
+        XCTAssertTrue(rm.pendingKernelAdds.isEmpty, "a refused destination must not become pending")
+    }
+}


### PR DESCRIPTION
Phase 1 of [the improvement plan](https://github.com/GeiserX/VPN-Bypass/blob/main/docs/IMPROVEMENT-PLAN-2026-08.md) — eliminates the traced root cause.

## Why
The instability was never our route **writes** (the corporate client debounces and skipped discovery **761/761** times under observation). It was **subprocess contention**: each `/sbin/route` fork+exec opens its own routing socket and blocks with no timeout; stacked execs starve other processes' route operations — including the VPN client's own periodic gateway-route **read**, whose timeout it misreads as "gateway route removed" → tunnel teardown (73/73 observed drops followed that chain).

## What
- **`RouteKernel`** (shared, byte-level-tested): `rt_msghdr` construction with the macOS-specific rules — 4-byte sockaddr alignment (not `sizeof(long)`), trimmed netmask `sa_len`, positional sockaddrs — plus `NET_RT_DUMP` parsing. All layouts from the SDK via `import Darwin`; nothing hand-computed.
- **Helper 2.0.0**: one owned PF_ROUTE socket (monotonic seq, errno from `write(2)`, `SHUT_RD`); **zero `/sbin/route` references remain in the helper**. One **silent** sysctl snapshot per batch replaces a forked, event-broadcasting `route -n get` per destination; already-correct routes cost **zero kernel events** — a restart against a correct kernel is fully silent.
- **Ownership**: every route tagged `RTF_PROTO1` (never PROTO3 — that is the kernel's own GC marker). Deletes treat ESRCH as success.
- **Startup sweep-by-signature**: tagged leftovers from a crash/kill identified from one dump — no journal, no prior state — and removed, including stranded VPN Only catch-alls on the no-VPN path. **The permanent fix for the #67 class.**
- **VPN gateway protection**: the tunnel gateway's host route is refused as a destination (vendor-documented connect-then-flap when disturbed).

## Verification gates
- Zero `/sbin/route` spawns in the helper ✓ · byte-level write/parse roundtrip ✓ · live silent dump unprivileged ✓ · `941 tests, 0 failures` ✓

BREAKING CHANGE: helper protocol 2.0.0 — one admin prompt on first launch after upgrade.