### PR TITLE
feat: honest enforcement UI — no green ON while enforcing nothing

### DIFF
--- a/Sources/VPNBypassCore/CommandRouter.swift
+++ b/Sources/VPNBypassCore/CommandRouter.swift
@@ -92,6 +92,33 @@ public struct ControlResult: Codable, Equatable, Sendable {
     public var supportedVersion: Int? = nil
     public var listenerPort: UInt16? = nil
     public var message: String? = nil
+    public var runtime: RuntimeStatus? = nil
+}
+
+/// Live enforcement facts for `status` — the answer to "is it actually working?", which the
+/// config-only response could not give: scripts (and bug reports) had no way to distinguish a
+/// healthy install from one whose helper was down and enforcing nothing.
+public struct RuntimeStatus: Codable, Equatable, Sendable {
+    public var helperReady: Bool
+    public var helperState: String
+    public var vpnConnected: Bool
+    public var vpnInterface: String? = nil
+    public var vpnType: String? = nil
+    public var enforcedRouteCount: Int
+    /// The single honest headline: VPN up AND helper ready AND routes installed.
+    public var enforcing: Bool
+
+    public init(helperReady: Bool, helperState: String, vpnConnected: Bool,
+                vpnInterface: String? = nil, vpnType: String? = nil,
+                enforcedRouteCount: Int, enforcing: Bool) {
+        self.helperReady = helperReady
+        self.helperState = helperState
+        self.vpnConnected = vpnConnected
+        self.vpnInterface = vpnInterface
+        self.vpnType = vpnType
+        self.enforcedRouteCount = enforcedRouteCount
+        self.enforcing = enforcing
+    }
 }
 
 /// Mirrors `Route` but never carries a credential value — the same discipline

--- a/Sources/VPNBypassCore/ControlSurface.swift
+++ b/Sources/VPNBypassCore/ControlSurface.swift
@@ -27,7 +27,24 @@ public enum ControlSurface {
     @MainActor
     public static func handle(_ request: ControlRequest) async -> ControlResponse {
         let ports = ProxyListenerManager.shared.activePorts
-        let (newConfig, response) = CommandRouter.apply(request, to: RouteManager.shared.config, listenerPorts: ports)
+        var (newConfig, response) = CommandRouter.apply(request, to: RouteManager.shared.config, listenerPorts: ports)
+
+        // `status` additionally reports LIVE enforcement facts. The config alone cannot answer
+        // "is it actually working?" — a down helper with a connected VPN looks identical to a
+        // healthy install in config terms while enforcing nothing.
+        if request.cmd == "status", response.ok {
+            let rm = RouteManager.shared
+            let helper = HelperManager.shared
+            response.result?.runtime = RuntimeStatus(
+                helperReady: helper.helperState.isReady,
+                helperState: helper.helperState.statusText,
+                vpnConnected: rm.isVPNConnected,
+                vpnInterface: rm.vpnInterface,
+                vpnType: rm.vpnType?.rawValue,
+                enforcedRouteCount: rm.uniqueRouteCount,
+                enforcing: rm.isVPNConnected && helper.helperState.isReady && !rm.activeRoutes.isEmpty
+            )
+        }
 
         // Read verbs (and any errored verb) leave the config untouched — don't
         // write config.json or churn listeners for a `status`/`route.list`.

--- a/Sources/VPNBypassCore/MenuBarViews.swift
+++ b/Sources/VPNBypassCore/MenuBarViews.swift
@@ -124,6 +124,7 @@ struct MenuContent: View {
     @EnvironmentObject var routeManager: RouteManager
     @EnvironmentObject var notificationManager: NotificationManager
     @EnvironmentObject var launchAtLoginManager: LaunchAtLoginManager
+    @ObservedObject private var helperManager = HelperManager.shared
     @State private var newDomain = ""
     @State private var isAddingDomain = false
     @State private var isVerifying = false
@@ -143,6 +144,7 @@ struct MenuContent: View {
         VStack(spacing: 0) {
             // App title
             titleHeader
+            helperDownBanner
             
             // Header with VPN status
             headerSection
@@ -213,25 +215,72 @@ struct MenuContent: View {
             
             Spacer()
             
-            // Live status indicator
+            // Live status indicator.
+            //
+            // "ON" is a claim about ENFORCEMENT, not about the VPN: with the helper down this
+            // app enforces nothing, and showing a green ON next to "VPN Connected" while zero
+            // routes were installed is exactly how a broken install looked healthy for weeks.
             HStack(spacing: 4) {
                 Circle()
-                    .fill(routeManager.isVPNConnected ? Theme.success : Theme.error)
+                    .fill(statusPill.color)
                     .frame(width: 6, height: 6)
-                    .shadow(color: routeManager.isVPNConnected ? Theme.success.opacity(0.6) : Theme.error.opacity(0.6), radius: 3)
+                    .shadow(color: statusPill.color.opacity(0.6), radius: 3)
 
-                Text(routeManager.isVPNConnected ? String(localized: "ON") : String(localized: "OFF"))
+                Text(statusPill.label)
                     .font(.system(size: 9, weight: .bold, design: .rounded))
-                    .foregroundColor(routeManager.isVPNConnected ? Theme.success : Theme.error)
+                    .foregroundColor(statusPill.color)
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
             .background(
                 Capsule()
-                    .fill(routeManager.isVPNConnected ? Theme.success.opacity(0.15) : Theme.error.opacity(0.15))
+                    .fill(statusPill.color.opacity(0.15))
             )
         }
         .padding(.bottom, 12)
+    }
+
+    /// What the pill may honestly claim right now.
+    private var statusPill: (label: String, color: Color) {
+        guard routeManager.isVPNConnected else {
+            return (String(localized: "OFF"), Theme.error)
+        }
+        if !helperManager.helperState.isReady {
+            return (String(localized: "NOT ENFORCING"), Theme.warning)
+        }
+        if routeManager.activeRoutes.isEmpty {
+            return (String(localized: "NO ROUTES"), Theme.warning)
+        }
+        return (String(localized: "ON"), Theme.success)
+    }
+
+    /// Shown at the top of the dropdown whenever the helper cannot enforce anything while a
+    /// VPN is connected — the state that used to be one log line nobody saw.
+    @ViewBuilder
+    private var helperDownBanner: some View {
+        if routeManager.isVPNConnected && !helperManager.helperState.isReady {
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(Theme.warning)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(String(localized: "Helper not running — nothing is being routed"))
+                        .font(.system(size: 11, weight: .semibold))
+                    Text(helperManager.helperState.statusText)
+                        .font(.system(size: 9))
+                        .foregroundColor(.secondary)
+                        .lineLimit(2)
+                }
+                Spacer()
+                Button(String(localized: "Fix…")) {
+                    openSettings()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding(10)
+            .background(RoundedRectangle(cornerRadius: 8).fill(Theme.warning.opacity(0.12)))
+            .padding(.bottom, 8)
+        }
     }
     
     // MARK: - Header

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -1058,6 +1058,11 @@ final class RouteManager: ObservableObject {
     func refreshRoutes() {
         guard HelperManager.shared.isHelperInstalled else {
             log(.error, "Cannot refresh routes: helper not ready (\(HelperManager.shared.helperState.statusText))")
+            // The most prominent button in the menu must never fail silently — this was a
+            // click that did nothing, with the only evidence in a log nobody reads.
+            NotificationManager.shared.notifyEnforcementFailed(
+                reason: String(localized: "Can't refresh: the privileged helper is not running. Open Settings → General to repair it.")
+            )
             return
         }
         Task {

--- a/Sources/VPNBypassCore/VPNBypassApp.swift
+++ b/Sources/VPNBypassCore/VPNBypassApp.swift
@@ -90,6 +90,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             let helperReady = await HelperManager.shared.ensureHelperReady()
             if !helperReady {
                 RouteManager.shared.log(.error, "Helper not ready: \(HelperManager.shared.helperState.statusText). Route application skipped.")
+                // This is a FIRST-RUN-reachable state, and it used to be one log line nobody
+                // saw: the menu showed a green ON while nothing was enforced. Tell the user.
+                NotificationManager.shared.notifyEnforcementFailed(
+                    reason: String(localized: "The privileged helper is not running — no routes are being enforced. Open Settings → General to repair it.")
+                )
                 // Detect VPN state for display, but skip route mutations that
                 // require the helper. This clears the "Setting Up..." spinner
                 // instead of hanging on it forever when the helper is absent.

--- a/Sources/vpnb/main.swift
+++ b/Sources/vpnb/main.swift
@@ -22,7 +22,7 @@ func printUsage() {
       vpnb <cmd> [key=value ...] [pass:-]
 
     Commands:
-      status                                    Mode, routes, and schema/version info
+      status                                    Mode, routes, live enforcement (helper/VPN/route facts)
       route.list                                List all routes
       route.set id=<uuid> [name=] [host=] [port=] [user=] [enabled=true|false] [pass:-]
                                                  Re-point a route's host/port/user/enabled/password

--- a/Tests/VPNBypassTests/ControlSurfaceTests.swift
+++ b/Tests/VPNBypassTests/ControlSurfaceTests.swift
@@ -90,6 +90,19 @@ final class ControlSurfaceTests: XCTestCase {
         XCTAssertTrue(ProxyListenerManager.shared.activePorts.isEmpty, "status must not start listeners")
     }
 
+    /// `status` must answer "is it actually working?" — live enforcement facts, not config
+    /// alone. In the test environment the helper is never ready, so the honest answer is
+    /// enforcing=false with helperReady=false; a config-only response could not say that.
+    func testStatusReportsLiveEnforcementFacts() async {
+        let resp = await ControlSurface.handle(ControlRequest(cmd: "status"))
+        XCTAssertTrue(resp.ok)
+        let runtime = resp.result?.runtime
+        XCTAssertNotNil(runtime, "status must carry the runtime block")
+        XCTAssertEqual(runtime?.helperReady, false, "no helper in tests — must be reported, not hidden")
+        XCTAssertEqual(runtime?.enforcing, false)
+        XCTAssertFalse(runtime?.helperState.isEmpty ?? true, "state text must name the reason")
+    }
+
     func testUnknownCommandErrorsWithoutMutating() async {
         var cfg = RouteManager.shared.config
         cfg.routes = [Route(name: "r", egress: .proxyHTTP, proxyHost: "h", proxyPort: 8001)]


### PR DESCRIPTION
Phase 2 (first slice) of [the improvement plan](https://github.com/GeiserX/VPN-Bypass/blob/main/docs/IMPROVEMENT-PLAN-2026-08.md).

A helper-down install showed a green **ON** pill + "VPN Connected" while **zero** routes were enforced; Refresh silently did nothing; no notification fired on the startup bail-out; `vpnb status` answered from config alone. Neither users nor scripts could ask "is it actually working?" — the #67 report class.

- Pill claims only what is true: **ON** = VPN up ∧ helper ready ∧ routes installed · **NOT ENFORCING** (helper down) · **NO ROUTES** · **OFF**
- Dropdown banner with the failure reason + **Fix…** button when a VPN is connected but nothing can be enforced
- `notifyEnforcementFailed` wired into the startup helper-not-ready bail-out (the exact first-run state)
- Refresh Routes reports failure instead of silently returning
- `vpnb status` gains a `runtime` block (`helperReady`, `helperState`, `vpnConnected`, interface, type, `enforcedRouteCount`, `enforcing`)

`942 tests, 0 failures`