### PR TITLE
feat: coexistence diagnostics card, first-run hint, doc/param cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ Set `VPNB_SOCKET` to override the socket path (default: `~/Library/Application S
 
 ### VPN Detection Logic
 
+> Running more than one VPN (e.g. a corporate client plus Tailscale), or local proxies? See
+> **[docs/COEXISTENCE.md](docs/COEXISTENCE.md)** for exactly what VPN Bypass will and will not
+> touch — one tunnel is acted on, Tailscale is never selected, loopback is never routed.
+
 The app intelligently detects corporate VPNs while avoiding false positives:
 
 | Interface Type | IP Range | Detection |
@@ -228,6 +232,9 @@ The app requires:
 - **Notifications**: Optional, for VPN status alerts (prompted on first launch)
 
 ## Troubleshooting
+
+Multi-VPN or proxy setups: **[docs/COEXISTENCE.md](docs/COEXISTENCE.md)** explains the selection
+and ownership rules, plus the commands to see what is actually happening.
 
 ### App won't open / "damaged" error (macOS Gatekeeper)
 

--- a/Sources/VPNBypassCore/MenuBarViews.swift
+++ b/Sources/VPNBypassCore/MenuBarViews.swift
@@ -145,6 +145,7 @@ struct MenuContent: View {
             // App title
             titleHeader
             helperDownBanner
+            nothingConfiguredHint
             
             // Header with VPN status
             headerSection
@@ -252,6 +253,30 @@ struct MenuContent: View {
             return (String(localized: "NO ROUTES"), Theme.warning)
         }
         return (String(localized: "ON"), Theme.success)
+    }
+
+    /// First-run honesty: a fresh install prompts for an admin password and then routes
+    /// NOTHING (empty domain list, every service disabled). Say so, instead of leaving a
+    /// silently inert app behind the most intrusive prompt it will ever show.
+    @ViewBuilder
+    private var nothingConfiguredHint: some View {
+        let nothingConfigured = routeManager.config.routingMode != .custom
+            && routeManager.config.domains.isEmpty
+            && !routeManager.config.services.contains(where: { $0.enabled })
+        if nothingConfigured && routeManager.activeRoutes.isEmpty {
+            HStack(spacing: 8) {
+                Image(systemName: "sparkles")
+                    .foregroundColor(Theme.blue)
+                Text(String(localized: "Nothing configured yet — add a domain below or enable a service in Settings to start bypassing."))
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer()
+            }
+            .padding(8)
+            .background(RoundedRectangle(cornerRadius: 8).fill(Theme.blue.opacity(0.08)))
+            .padding(.bottom, 8)
+        }
     }
 
     /// Shown at the top of the dropdown whenever the helper cannot enforce anything while a

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -701,7 +701,7 @@ final class RouteManager: ObservableObject {
         let tsIPs = await tailscaleSelfIPs()
         var candidates: [VPNCandidate] = []
         for i in interfaces.indices {
-            let isValid = await isCorporateVPNIP(interfaces[i].ip, hintType: hintType)
+            let isValid = await isCorporateVPNIP(interfaces[i].ip)
             interfaces[i].isValidCorporateIP = isValid
             guard interfaces[i].isVPN else { continue }
             candidates.append(VPNCandidate(
@@ -745,7 +745,7 @@ final class RouteManager: ObservableObject {
     
     /// Which interface the default route currently exits through, or nil if unreadable.
     /// This is the only direct evidence of which tunnel is actually carrying traffic.
-    private func currentDefaultRouteInterface() async -> String? {
+    func currentDefaultRouteInterface() async -> String? {
         guard let result = await runProcessAsync("/sbin/route", arguments: ["-n", "get", "default"], timeout: 5.0) else {
             return nil
         }
@@ -796,6 +796,28 @@ final class RouteManager: ObservableObject {
     /// (`vpnInterface`/`vpnType`) that classic modes rely on — that path is untouched.
     /// The Tailscale utun is flagged so it isn't offered as a plain VPN egress
     /// (Tailscale egress has its own peer-proxy route type).
+    /// Everything the coexistence diagnostics card shows, gathered in one pass.
+    struct CoexistenceSnapshot: Equatable {
+        let links: [VPNLink]
+        let selectedInterface: String?
+        let defaultRouteInterface: String?
+        /// Kernel routes carrying OUR ownership tag (RTF_PROTO1) — ground truth of what this
+        /// app currently owns, read silently from the table itself.
+        let taggedRouteCount: Int
+    }
+
+    /// On-demand only — never call from a timer. `listVPNLinks` spawns `ifconfig` and
+    /// `tailscale status`, which the hot paths deliberately avoid (see the needsLinks guard).
+    func coexistenceSnapshot() async -> CoexistenceSnapshot {
+        let links = await listVPNLinks()
+        let defaultIface = await currentDefaultRouteInterface()
+        let tagged = RouteKernel.currentTable()?.filter { $0.isOurs }.count ?? 0
+        return CoexistenceSnapshot(links: links,
+                                   selectedInterface: vpnInterface,
+                                   defaultRouteInterface: defaultIface,
+                                   taggedRouteCount: tagged)
+    }
+
     func listVPNLinks() async -> [VPNLink] {
         guard let result = await runProcessAsync("/sbin/ifconfig", timeout: 5.0) else { return [] }
 
@@ -874,8 +896,9 @@ final class RouteManager: ObservableObject {
     }
 
     /// Check if IP is likely a corporate VPN (not Tailscale mesh, not localhost, etc.)
-    /// hintType comes from process detection -- used to distinguish Zscaler/WARP from Tailscale in the shared CGNAT range.
-    private func isCorporateVPNIP(_ ip: String, hintType: VPNType?) async -> Bool {
+    /// (CGNAT disambiguation — Tailscale vs Zscaler/WARP — is done by classifyCGNATAddress,
+    /// not by the process hint: a machine-wide process match cannot attribute an ADDRESS.)
+    private func isCorporateVPNIP(_ ip: String) async -> Bool {
         let parts = ip.components(separatedBy: ".")
         guard parts.count == 4,
               let first = Int(parts[0]),
@@ -3856,7 +3879,7 @@ final class RouteManager: ObservableObject {
     /// 100.112.0.0/12 capture range dropped WHILE GP is up: a listener there would dial
     /// a peer address the GP tunnel hijacks (longest-prefix match), so the hop would
     /// silently leave via GP instead of the tailnet. The route stays in config and its
-    /// listener returns as soon as GP disconnects. See docs/research/2026-07-03-tailnet-probe.md.
+    /// listener returns as soon as GP disconnects. (Tailnet-probe research, 2026-07-03 — see the guardCatchAllUnderGlobalProtect rationale.)
     func listenerRoutesRespectingGPShadow() -> [Route] {
         guard vpnType == .globalProtect else { return config.routes }
         return config.routes.filter { route in

--- a/Sources/VPNBypassCore/SettingsView.swift
+++ b/Sources/VPNBypassCore/SettingsView.swift
@@ -1906,6 +1906,11 @@ struct GeneralTab: View {
                 }
             }
             
+            // Coexistence diagnostics: which tunnels are up, which one this app acts on,
+            // which carries the default route — the three facts every multi-VPN confusion
+            // turns on, previously answerable only by hand-run shell commands.
+            CoexistenceCard()
+
             // About section
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
@@ -2790,3 +2795,90 @@ struct BrandedTitlebarView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
+
+// MARK: - Coexistence Diagnostics
+
+/// Read-only view of every live tunnel and what this app is doing about them. Refreshes on
+/// appear and on demand ONLY — the underlying enumeration spawns `ifconfig` and
+/// `tailscale status`, which must never sit on a timer.
+struct CoexistenceCard: View {
+    @EnvironmentObject var routeManager: RouteManager
+    @State private var snapshot: RouteManager.CoexistenceSnapshot?
+    @State private var isRefreshing = false
+
+    var body: some View {
+        SettingsCard(title: "Coexistence", icon: "point.3.connected.trianglepath.dotted", iconColor: Theme.blue) {
+            if let snapshot {
+                if snapshot.links.isEmpty {
+                    Text(String(localized: "No VPN tunnels are up."))
+                        .font(.system(size: 12))
+                        .foregroundColor(Theme.textSecondary)
+                } else {
+                    ForEach(snapshot.links) { link in
+                        HStack(spacing: 6) {
+                            Text(link.interface)
+                                .font(.system(size: 12, weight: .medium, design: .monospaced))
+                            Text(link.label)
+                                .font(.system(size: 11))
+                                .foregroundColor(Theme.textSecondary)
+                                .lineLimit(1)
+                            Spacer()
+                            if link.interface == snapshot.selectedInterface {
+                                TagBadge(text: String(localized: "acting on"), color: Theme.success)
+                            }
+                            if link.interface == snapshot.defaultRouteInterface {
+                                TagBadge(text: String(localized: "default route"), color: Theme.blue)
+                            }
+                            if link.isTailscale {
+                                TagBadge(text: "Tailscale", color: Theme.warning)
+                            }
+                        }
+                    }
+                }
+                Divider().background(Theme.divider)
+                StatusRow(label: "Routes owned (kernel-tagged)", value: "\(snapshot.taggedRouteCount)")
+                Text(String(localized: "This app acts on ONE tunnel and tags every route it installs in the kernel itself. Tailscale and loopback are never touched."))
+                    .font(.system(size: 10))
+                    .foregroundColor(Theme.textSecondary)
+            } else {
+                Text(String(localized: "Reading network state…"))
+                    .font(.system(size: 12))
+                    .foregroundColor(Theme.textSecondary)
+            }
+
+            HStack {
+                Spacer()
+                Button {
+                    Task { await refresh() }
+                } label: {
+                    Label(String(localized: "Refresh"), systemImage: "arrow.clockwise")
+                        .font(.system(size: 11))
+                }
+                .disabled(isRefreshing)
+            }
+        }
+        .task { await refresh() }
+    }
+
+    private func refresh() async {
+        isRefreshing = true
+        snapshot = await routeManager.coexistenceSnapshot()
+        isRefreshing = false
+    }
+}
+
+/// Small capsule badge used by the coexistence rows.
+struct TagBadge: View {
+    let text: String
+    let color: Color
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundColor(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(color.opacity(0.15)))
+    }
+}
+


### PR DESCRIPTION
Phase 2/3 slice of [the improvement plan](https://github.com/GeiserX/VPN-Bypass/blob/main/docs/IMPROVEMENT-PLAN-2026-08.md).

- **Coexistence card** (Settings → General): every live tunnel with `acting on` / `default route` / `Tailscale` badges + the count of routes this app owns, read from the **kernel's ownership tags** (ground truth, not the in-memory model). On-appear/on-demand refresh only.
- **First-run hint**: fresh installs used to prompt for an admin password and then silently route nothing.
- README links the previously-orphaned `docs/COEXISTENCE.md`.
- `isCorporateVPNIP` loses its never-read `hintType` param; stale doc reference fixed.

`942 tests, 0 failures`