### PR TITLE
feat: CLI parity for VPN routes — pins settable and visible from vpnb

### DIFF
--- a/Sources/VPNBypassCore/CommandRouter.swift
+++ b/Sources/VPNBypassCore/CommandRouter.swift
@@ -136,6 +136,9 @@ public struct SanitizedRoute: Codable, Equatable, Sendable {
     public var hasProxyUser: Bool
     public var hasPassword: Bool
     public var tailscaleExitNode: String?
+    /// The pinned tunnel of a VPN route (nil = primary/automatic) — previously omitted, so
+    /// the one scriptable surface could not even display a pin the GUI had created.
+    public var vpnSelector: VPNSelector?
     public var localListenPort: Int?
     /// The route's LIVE loopback listener port, if a forwarder is currently
     /// running for it (nil for non-proxy routes or ones not yet started).
@@ -151,6 +154,7 @@ public struct SanitizedRoute: Codable, Equatable, Sendable {
         hasProxyUser = !(route.proxyUser ?? "").isEmpty
         hasPassword = !(route.proxyPass ?? "").isEmpty
         tailscaleExitNode = route.tailscaleExitNode
+        vpnSelector = route.vpnSelector
         localListenPort = route.localListenPort
         self.listenerPort = listenerPort
     }
@@ -346,14 +350,27 @@ enum CommandRouter {
             validatedPort = p
         }
 
-        let route = Route(
+        guard let egress = parseEgressType(request.args?["type"]) else {
+            return errorResponse(config, code: "invalid_type",
+                                 message: "type must be one of: http, socks5, tailscale, vpn")
+        }
+
+        var route = Route(
             name: name,
-            egress: parseEgressType(request.args?["type"]),
+            egress: egress,
             proxyHost: request.args?["host"],
             proxyPort: validatedPort,
             proxyUser: request.args?["user"],
             proxyPass: request.secrets?["pass"]
         )
+        // A VPN route may pin a specific tunnel: `--interface utunX [--product "Label"]`.
+        // The label is the durable half — utun indices renumber across reconnects, and the
+        // resolver prefers the label match for exactly that reason.
+        if egress == .vpnDefault, let iface = request.args?["interface"], !iface.isEmpty {
+            route.vpnSelector = VPNSelector(kind: .interface,
+                                            interfaceName: iface,
+                                            productHint: request.args?["product"])
+        }
         var updated = config
         updated.routes.append(route)
         let sanitized = SanitizedRoute(route, listenerPort: listenerPorts[route.id])
@@ -487,11 +504,16 @@ enum CommandRouter {
         return isValidIPv4(String(parts[0]))
     }
 
-    private static func parseEgressType(_ s: String?) -> Egress {
+    /// nil (omitted) defaults to http. An UNRECOGNIZED string is an error — it used to fall
+    /// through to proxyHTTP silently, so `--type vpn` (a real egress the GUI can create) quietly
+    /// built a proxy route with no host instead of failing loudly.
+    private static func parseEgressType(_ s: String?) -> Egress? {
         switch s {
+        case nil, "http": return .proxyHTTP
         case "socks5": return .proxySOCKS5
         case "tailscale": return .tailscaleExit
-        default: return .proxyHTTP  // "http" and anything unrecognized
+        case "vpn": return .vpnDefault
+        default: return nil
         }
     }
 }

--- a/Sources/vpnb/main.swift
+++ b/Sources/vpnb/main.swift
@@ -28,7 +28,8 @@ func printUsage() {
                                                  Re-point a route's host/port/user/enabled/password
       route.enable id=<uuid>                    Enable a route
       route.disable id=<uuid>                   Disable a route
-      route.add name=<name> [type=http|socks5|tailscale] [host=] [port=] [user=] [pass:-]
+      route.add name=<name> [type=http|socks5|tailscale|vpn] [host=] [port=] [user=] [pass:-]
+                                                [interface=utunX] [product=<label>]  (type=vpn: pin a tunnel)
                                                  Add a new route
       route.rm id=<uuid>                        Remove a route
       rule.list                                 List all rules

--- a/Tests/VPNBypassTests/CommandRouterTests.swift
+++ b/Tests/VPNBypassTests/CommandRouterTests.swift
@@ -173,7 +173,7 @@ final class CommandRouterTests: XCTestCase {
         XCTAssertFalse(json.contains("cust-user"), "response JSON must never carry the raw username either")
     }
 
-    func testRouteAddMissingNameIsInvalidArgsAndUnrecognizedTypeDefaultsToHTTP() {
+    func testRouteAddMissingNameIsInvalidArgsAndAbsentTypeDefaultsToHTTP() {
         let config = RouteManager.Config()
 
         let (unchanged, badResp) = CommandRouter.apply(ControlRequest(cmd: "route.add"), to: config)
@@ -182,7 +182,7 @@ final class CommandRouterTests: XCTestCase {
 
         let (withRoute, okResp) = CommandRouter.apply(ControlRequest(cmd: "route.add", args: ["name": "Plain"]), to: config)
         XCTAssertTrue(okResp.ok)
-        XCTAssertEqual(withRoute.routes.first?.egress, .proxyHTTP, "absent/unrecognized type defaults to HTTP proxy")
+        XCTAssertEqual(withRoute.routes.first?.egress, .proxyHTTP, "ABSENT type defaults to HTTP proxy; an unrecognized one is now an error (see testRouteAddRejectsUnknownEgressType)")
     }
 
     // MARK: - route.rm
@@ -431,5 +431,48 @@ final class CommandRouterTests: XCTestCase {
                 XCTAssertFalse(json.contains(marker), "response leaked secret marker \(marker): \(json)")
             }
         }
+    }
+}
+
+// MARK: - CLI parity for VPN routes (pins)
+
+extension CommandRouterTests {
+
+    /// An unrecognized egress type must be an ERROR. It used to fall through to proxyHTTP
+    /// silently, so a typo (or the then-unsupported "vpn") built a proxy route with no host.
+    func testRouteAddRejectsUnknownEgressType() {
+        let (config, response) = CommandRouter.apply(
+            ControlRequest(cmd: "route.add", args: ["name": "r", "type": "bogus"]),
+            to: RouteManager.Config())
+        XCTAssertFalse(response.ok)
+        XCTAssertEqual(response.error?.code, "invalid_type")
+        XCTAssertTrue(config.routes.isEmpty, "an errored verb must not mutate")
+    }
+
+    /// `type=vpn` with an interface pin must land in config AND be visible in the sanitized
+    /// response — the scriptable surface previously could neither set nor display a pin.
+    func testRouteAddCanPinAVPNTunnel() {
+        let (config, response) = CommandRouter.apply(
+            ControlRequest(cmd: "route.add",
+                           args: ["name": "corp", "type": "vpn",
+                                  "interface": "utun9", "product": "GlobalProtect"]),
+            to: RouteManager.Config())
+        XCTAssertTrue(response.ok)
+        let added = config.routes.first { $0.name == "corp" }
+        XCTAssertEqual(added?.egress, .vpnDefault)
+        XCTAssertEqual(added?.vpnSelector?.kind, .interface)
+        XCTAssertEqual(added?.vpnSelector?.interfaceName, "utun9")
+        XCTAssertEqual(added?.vpnSelector?.productHint, "GlobalProtect")
+        XCTAssertEqual(response.result?.routes?.first?.vpnSelector?.interfaceName, "utun9",
+                       "vpnb status/route.list must be able to DISPLAY the pin")
+    }
+
+    /// A plain `type=vpn` without an interface is the automatic primary — no selector.
+    func testRouteAddPlainVPNHasNoSelector() {
+        let (config, response) = CommandRouter.apply(
+            ControlRequest(cmd: "route.add", args: ["name": "vpnauto", "type": "vpn"]),
+            to: RouteManager.Config())
+        XCTAssertTrue(response.ok)
+        XCTAssertNil(config.routes.first { $0.name == "vpnauto" }?.vpnSelector)
     }
 }


### PR DESCRIPTION
Phase 3 slice of [the improvement plan](https://github.com/GeiserX/VPN-Bypass/blob/main/docs/IMPROVEMENT-PLAN-2026-08.md) — closes the gaps found by the config-surface research.

- `type=vpn` is a valid egress; `interface=utunX [product=<label>]` pins a tunnel (label = durable half; utun indices renumber)
- An **unrecognized** type is now `invalid_type` instead of silently becoming an HTTP proxy route with no host; absent type still defaults to http
- `SanitizedRoute` carries `vpnSelector`, so `vpnb status` / `route.list` can finally **display** pins the GUI created

`945 tests, 0 failures`