### PR TITLE
fix: disconnect notification no longer reports kept routes as failures

### DIFF
--- a/Sources/VPNBypassCore/NotificationManager.swift
+++ b/Sources/VPNBypassCore/NotificationManager.swift
@@ -116,15 +116,29 @@ final class NotificationManager: NSObject, ObservableObject, UNUserNotificationC
         )
     }
     
-    func notifyVPNDisconnected(wasInterface: String?, routesRemaining: Int = 0) {
-        guard notificationsEnabled && notifyOnVPNDisconnect else { return }
-
-        let suffix = routesRemaining > 0
-            ? String(localized: "\(routesRemaining) route(s) could not be removed.")
-            : String(localized: "Routes cleared.")
-        let body = wasInterface != nil
+    /// Kept-by-design and failed-removal are DIFFERENT facts and must read differently.
+    /// Bypass mode deliberately keeps local-gateway routes on disconnect (a reconnect finds
+    /// them already correct — zero churn); reporting that count as "could not be removed"
+    /// made the churn fix look like a malfunction.
+    nonisolated static func disconnectedBody(wasInterface: String?, routesKept: Int, routesFailed: Int) -> String {
+        let suffix: String
+        if routesFailed > 0 {
+            suffix = String(localized: "\(routesFailed) route(s) could not be removed.")
+        } else if routesKept > 0 {
+            suffix = String(localized: "Keeping \(routesKept) bypass route(s) — they use your normal connection and will be reused on reconnect.")
+        } else {
+            suffix = String(localized: "Routes cleared.")
+        }
+        return wasInterface != nil
             ? String(localized: "Disconnected from \(wasInterface!). \(suffix)")
             : String(localized: "VPN connection lost. \(suffix)")
+    }
+
+    func notifyVPNDisconnected(wasInterface: String?, routesKept: Int = 0, routesFailed: Int = 0) {
+        guard notificationsEnabled && notifyOnVPNDisconnect else { return }
+
+        let body = Self.disconnectedBody(wasInterface: wasInterface,
+                                         routesKept: routesKept, routesFailed: routesFailed)
 
         sendNotification(
             title: String(localized: "VPN Disconnected"),

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -561,6 +561,8 @@ final class RouteManager: ObservableObject {
             //
             // VPN Only keeps the full teardown: its catch-alls are leak-critical and its listed
             // destinations point at a gateway that is now gone, so there is nothing worth keeping.
+            var keptCount = 0
+            var failedCount = 0
             if config.routingMode == .bypass {
                 let stale = Self.vpnBoundDestinations(
                     activeRoutes: activeRoutes,
@@ -569,20 +571,28 @@ final class RouteManager: ObservableObject {
                 )
                 if stale.isEmpty {
                     log(.info, "VPN gone; \(activeRoutes.count) bypass route(s) still egress the local gateway — keeping them")
+                    keptCount = activeRoutes.count
                 } else {
                     log(.info, "VPN gone; removing \(stale.count) VPN-bound route(s), keeping \(activeRoutes.count - stale.count) local-gateway route(s)")
                     let result = await removeRoutesBatchVia(stale)
                     let removed = Set(stale).subtracting(result.failedDestinations)
                     activeRoutes.removeAll { removed.contains($0.destination) }
+                    failedCount = result.failedDestinations.count
+                    keptCount = activeRoutes.count - failedCount
                 }
             } else {
                 await removeAllRoutes()
+                // Whatever teardown retained is a genuine failed removal (see removeAllRoutes).
+                failedCount = activeRoutes.count
             }
             routeVerificationResults.removeAll()
             lastTailscaleSelfFingerprint = nil
             vpnGateway = nil
-            // Notify after cleanup so notification reflects actual state
-            NotificationManager.shared.notifyVPNDisconnected(wasInterface: oldInterface, routesRemaining: activeRoutes.count)
+            // Notify after cleanup so the notification reflects the ACTUAL state — and names
+            // kept-by-design separately from failed-removal.
+            NotificationManager.shared.notifyVPNDisconnected(wasInterface: oldInterface,
+                                                             routesKept: keptCount,
+                                                             routesFailed: failedCount)
         }
     }
     

--- a/Tests/VPNBypassTests/DisconnectNotificationTests.swift
+++ b/Tests/VPNBypassTests/DisconnectNotificationTests.swift
@@ -1,0 +1,38 @@
+// DisconnectNotificationTests.swift
+// Kept-by-design and failed-removal are different facts and must read differently.
+//
+// Bypass mode deliberately KEEPS local-gateway routes on VPN disconnect — a reconnect finds
+// them already correct and costs zero kernel churn (the #65 fix). The notification template
+// predated that behaviour and rendered ANY remaining count as "could not be removed", so the
+// churn fix's first live run reported itself as a malfunction ("374 routes could not be
+// removed" — all 374 were correct, deliberate, and pointing at the local gateway).
+
+import XCTest
+@testable import VPNBypassCore
+
+final class DisconnectNotificationTests: XCTestCase {
+
+    func testKeptRoutesReadAsKeptNotFailed() {
+        let body = NotificationManager.disconnectedBody(wasInterface: "utun9", routesKept: 374, routesFailed: 0)
+        XCTAssertTrue(body.contains("Keeping 374"), body)
+        XCTAssertFalse(body.contains("could not be removed"), "kept-by-design must never read as a failure")
+    }
+
+    func testGenuineFailuresStillReadAsFailures() {
+        let body = NotificationManager.disconnectedBody(wasInterface: "utun9", routesKept: 0, routesFailed: 3)
+        XCTAssertTrue(body.contains("3 route(s) could not be removed"), body)
+    }
+
+    /// Failures outrank kept in the headline — a real problem must not be softened by the
+    /// routine fact that some routes were kept.
+    func testFailuresOutrankKept() {
+        let body = NotificationManager.disconnectedBody(wasInterface: nil, routesKept: 100, routesFailed: 2)
+        XCTAssertTrue(body.contains("could not be removed"))
+        XCTAssertFalse(body.contains("Keeping"))
+    }
+
+    func testCleanTeardownSaysCleared() {
+        let body = NotificationManager.disconnectedBody(wasInterface: "utun9", routesKept: 0, routesFailed: 0)
+        XCTAssertTrue(body.contains("Routes cleared"), body)
+    }
+}


### PR DESCRIPTION
First live run of the disconnect-keep behaviour reported itself as a malfunction: **"374 routes could not be removed"** — all 374 were correct, deliberate, local-gateway routes kept so a reconnect costs zero churn (the #65 fix working as designed).

The notification template predated keep-on-disconnect and rendered any remaining count as a failure.

- Kept-by-design → *"Keeping N bypass route(s) — they use your normal connection and will be reused on reconnect."*
- Genuine failures → still *"N route(s) could not be removed."* and they outrank the kept count
- Clean teardown → *"Routes cleared."*

Pure body builder + 4 tests · `953 tests, 0 failures`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN disconnect notifications to distinguish between routes intentionally kept and routes that could not be removed.
  * Notifications now clearly report clean disconnections, retained bypass routes, and failed route removals.
  * Ensured failure messages take precedence when both retained and failed routes are present.

* **Tests**
  * Added coverage for all disconnect notification outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->