### PR TITLE
fix: correct the identity lockup, centring and title bar mark

### DIFF
--- a/Sources/VPNBypassCore/MenuBarViews.swift
+++ b/Sources/VPNBypassCore/MenuBarViews.swift
@@ -103,9 +103,13 @@ struct MenuBarLabel: View {
 
 struct BrandedAppName: View {
     var fontSize: CGFloat = 15
-    /// Show the mark alongside the type (the full lockup). Off where the mark would repeat
-    /// something already on screen.
-    var showsMark: Bool = true
+    /// Show the mark alongside the type (the full lockup).
+    ///
+    /// Defaults OFF. Every surface that shows this wordmark already has the mark nearby — the
+    /// app icon above it, or the menu bar icon it hangs from — so showing it again duplicated
+    /// the mark AND pushed the type off-centre, because the lockup centres as one unit while
+    /// the icon above centres on its own.
+    var showsMark: Bool = false
 
     var body: some View {
         HStack(spacing: 0) {
@@ -120,9 +124,13 @@ struct BrandedAppName: View {
             }
             // Weight contrast, not colour contrast, carries the lockup — the same relationship
             // the banner and app icon use, so the three read as one identity.
+            //
+            // The gap is required: set solid, "VPN"+"Bypass" reads as one word, "VPNBypass".
+            // The banner has always had this gap; the SwiftUI lockup was missing it.
             Text("VPN")
                 .font(.system(size: fontSize, weight: .heavy, design: .rounded))
                 .foregroundColor(Theme.textPrimary)
+                .padding(.trailing, fontSize * 0.16)
 
             Text("Bypass")
                 .font(.system(size: fontSize, weight: .light, design: .rounded))

--- a/Sources/VPNBypassCore/SettingsView.swift
+++ b/Sources/VPNBypassCore/SettingsView.swift
@@ -2380,7 +2380,7 @@ struct InfoTab: View {
     }
     
     private var appInfoSection: some View {
-        VStack(alignment: .center, spacing: 12) {
+        VStack(alignment: .center, spacing: 10) {
             // App logo from bundle
             if let logoPath = Bundle.main.path(forResource: "VPNBypass", ofType: "png"),
                let nsImage = NSImage(contentsOfFile: logoPath) {
@@ -2388,27 +2388,33 @@ struct InfoTab: View {
                     .interpolation(.high)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(width: 80, height: 80)
+                    .frame(width: 96, height: 96)
+                    .clipShape(RoundedRectangle(cornerRadius: 21.6, style: .continuous))
+                    .shadow(color: .black.opacity(0.35), radius: 10, y: 4)
             } else {
-                Image(systemName: "shield.checkered")
+                Image(systemName: "arrow.right")
                     .font(.system(size: 48))
-                    .foregroundStyle(Theme.Brand.blueGradient)
+                    .foregroundColor(Theme.Brand.sky)
             }
-            
-            // App name with branded colors
-            BrandedAppName(fontSize: 24)
-            
+
+            // Type only — the icon directly above IS the mark. Repeating it here duplicated
+            // the mark and, because a mark+type lockup centres as one unit, left the type
+            // visibly off-centre under the icon.
+            BrandedAppName(fontSize: 26)
+                .padding(.top, 2)
+
             Text("v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown")")
-                .font(.system(size: 12, design: .monospaced))
+                .font(.system(size: 11, weight: .medium, design: .monospaced))
                 .foregroundColor(Theme.textTertiary)
 
             Text("Route specific traffic around your corporate VPN")
                 .font(.system(size: 13))
                 .foregroundColor(Theme.textSecondary)
                 .multilineTextAlignment(.center)
+                .padding(.top, 2)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 20)
+        .padding(.vertical, 26)
     }
     
     private var authorSection: some View {
@@ -2763,31 +2769,24 @@ struct BrandedTitlebarView: View {
         HStack {
             Spacer()
 
-            HStack(spacing: 6) {
-                // App logo from bundle
-                if let logoPath = Bundle.main.path(forResource: "VPNBypass", ofType: "png"),
-                   let nsImage = NSImage(contentsOfFile: logoPath) {
-                    Image(nsImage: nsImage)
-                        .interpolation(.high)
+            // The FLAT mark, tinted — not the squircle app icon scaled to 18px, which turns to
+            // mud at that size because its gradient ground and rounded shape carry no detail
+            // there. The title bar is exactly what the template glyph is drawn for.
+            HStack(spacing: 7) {
+                if let mark = Bundle.main.image(forResource: "menubar-icon-active") {
+                    Image(nsImage: mark)
+                        .renderingMode(.template)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(width: 18, height: 18)
+                        .frame(width: 15, height: 15)
+                        .foregroundColor(Theme.Brand.sky)
                 } else {
-                    Image(systemName: "shield.checkered")
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(Theme.Brand.blueGradient)
+                    Image(systemName: "arrow.right")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(Theme.Brand.sky)
                 }
 
-                // Branded name
-                HStack(spacing: 0) {
-                    Text("VPN")
-                        .font(.system(size: 13, weight: .bold, design: .rounded))
-                        .foregroundStyle(Theme.Brand.blueGradient)
-
-                    Text("Bypass")
-                        .font(.system(size: 13, weight: .semibold, design: .rounded))
-                        .foregroundStyle(Theme.Brand.silverGradient)
-                }
+                BrandedAppName(fontSize: 13)
             }
 
             Spacer()


### PR DESCRIPTION
Three faults visible in the Settings window:

1. **No gap between the words** — the wordmark read as `VPNBypass`. The banner has always had that gap; the SwiftUI lockup was missing it.
2. **The mark appeared twice in the Info tab** — once as the app icon, once inside the wordmark below — and that is *why* the type looked off-centre: a mark+type lockup centres as **one unit**, so the type inside it sits right of centre while the icon above centres on its own. The wordmark's mark now defaults **off**.
3. **The title bar scaled the squircle app icon to 18px**, where its gradient ground carries no detail and turns to mud. Now uses the flat template mark tinted sky — what that glyph exists for — via the shared `BrandedAppName`.

Info tab also tightened: icon 80→96 with continuous-corner clip + soft shadow, tighter rhythm, version de-emphasised.

`953 tests, 0 failures`