### PR TITLE
feat: surface every usable egress in Custom Routes

### DIFF
--- a/Sources/VPNBypassCore/ConfigModel.swift
+++ b/Sources/VPNBypassCore/ConfigModel.swift
@@ -96,6 +96,9 @@ struct Config: Codable {
     var defaultRouteId: UUID? = nil
     var schemaVersion: Int = 1
     var multiRouteEnabled: Bool = false  // Opt-in experimental: show Routes tab and start proxy listeners
+    /// Tunnels seen previously, so a VPN that is not connected right now can still be chosen
+    /// for a route or a pin. Live enumeration only reports tunnels that are UP.
+    var rememberedVPNLinks: [RouteManager.RememberedLink] = []
     /// Optional pin: act ONLY on this tunnel when it is up and eligible ("utun9"). Constrains
     /// automatic selection; a stale pin degrades to automatic with a logged warning.
     var pinnedVPNInterface: String? = nil
@@ -124,6 +127,7 @@ struct Config: Codable {
         defaultRouteId = try container.decodeIfPresent(UUID.self, forKey: .defaultRouteId)
         schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 1
         multiRouteEnabled = try container.decodeIfPresent(Bool.self, forKey: .multiRouteEnabled) ?? false
+        rememberedVPNLinks = try container.decodeIfPresent([RouteManager.RememberedLink].self, forKey: .rememberedVPNLinks) ?? []
         pinnedVPNInterface = try container.decodeIfPresent(String.self, forKey: .pinnedVPNInterface)
         pinnedVPNProductHint = try container.decodeIfPresent(String.self, forKey: .pinnedVPNProductHint)
 

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -836,6 +836,36 @@ final class RouteManager: ObservableObject {
     /// (`vpnInterface`/`vpnType`) that classic modes rely on — that path is untouched.
     /// The Tailscale utun is flagged so it isn't offered as a plain VPN egress
     /// (Tailscale egress has its own peer-proxy route type).
+    /// A tunnel seen at some point on this machine. Kept so a route or a pin can name a VPN
+    /// that is not connected at this moment — live enumeration only ever reports tunnels that
+    /// are UP, which made it impossible to pre-configure a VPN you were not currently using.
+    struct RememberedLink: Codable, Equatable, Identifiable {
+        let interface: String
+        let label: String
+        var id: String { interface }
+    }
+
+    /// Live tunnels merged with previously-seen ones (deduplicated, live first). `isLive`
+    /// tells the UI which are connected right now.
+    func selectableVPNLinks() async -> [(link: RememberedLink, isLive: Bool)] {
+        let live = await listVPNLinks().filter { !$0.isTailscale }
+        var out = live.map { (RememberedLink(interface: $0.interface, label: $0.label), true) }
+        // Record what we just saw, so it stays offerable after the VPN disconnects.
+        var remembered = config.rememberedVPNLinks
+        for l in live where !remembered.contains(where: { $0.interface == l.interface && $0.label == l.label }) {
+            remembered.removeAll { $0.interface == l.interface }
+            remembered.append(RememberedLink(interface: l.interface, label: l.label))
+        }
+        if remembered != config.rememberedVPNLinks {
+            config.rememberedVPNLinks = remembered
+            saveConfig()
+        }
+        for r in remembered where !out.contains(where: { $0.0.interface == r.interface }) {
+            out.append((r, false))
+        }
+        return out
+    }
+
     /// Everything the coexistence diagnostics card shows, gathered in one pass.
     struct CoexistenceSnapshot: Equatable {
         let links: [VPNLink]
@@ -3937,6 +3967,10 @@ final class RouteManager: ObservableObject {
         let name: String
         let ip: String
         let online: Bool
+        /// The peer advertises itself as a Tailscale exit node (`ExitNodeOption`). Worth
+        /// showing because it is usually a tiny minority of a tailnet, and because it is the
+        /// only peer class that can carry general internet traffic without extra setup.
+        let exitNodeCapable: Bool
         var id: String { ip }
     }
 
@@ -3954,10 +3988,15 @@ final class RouteManager: ObservableObject {
                 ?? (peer["DNSName"] as? String)?.components(separatedBy: ".").first
                 ?? ip4
             let online = (peer["Online"] as? Bool) ?? false
-            out.append(TailscalePeer(name: host, ip: ip4, online: online))
+            let exitCapable = (peer["ExitNodeOption"] as? Bool) ?? false
+            out.append(TailscalePeer(name: host, ip: ip4, online: online, exitNodeCapable: exitCapable))
         }
+        // Exit-capable first, then online, then alphabetical — the ordering that puts the
+        // peers that can actually carry traffic at the top of a 17-device list.
         return out.sorted { a, b in
-            a.online != b.online ? a.online : a.name.lowercased() < b.name.lowercased()
+            if a.exitNodeCapable != b.exitNodeCapable { return a.exitNodeCapable }
+            if a.online != b.online { return a.online }
+            return a.name.lowercased() < b.name.lowercased()
         }
     }
 

--- a/Sources/VPNBypassCore/RoutesTab.swift
+++ b/Sources/VPNBypassCore/RoutesTab.swift
@@ -468,6 +468,9 @@ struct RouteEditorSheet: View {
     @State private var selectedVPNInterface: String
     @State private var vpnProductHint: String
     @State private var vpnLinks: [RouteManager.VPNLink] = []
+    /// Live tunnels PLUS ones seen before, so a VPN that is currently disconnected can still
+    /// be chosen — live enumeration alone only ever reports tunnels that are UP.
+    @State private var selectableLinks: [(link: RouteManager.RememberedLink, isLive: Bool)] = []
 
     init(
         editingRoute: Route?,
@@ -586,7 +589,11 @@ struct RouteEditorSheet: View {
                                             Circle()
                                                 .fill(peer.online ? Theme.success : Theme.textTertiary)
                                                 .frame(width: 6, height: 6)
-                                            Text(peer.name)
+                                            // An exit-capable peer is usually a small minority
+                                            // of a tailnet, and it is the only kind that can
+                                            // carry general internet traffic without extra
+                                            // setup — so say which ones they are.
+                                            Text(peer.exitNodeCapable ? "\(peer.name) · exit node" : peer.name)
                                         }
                                         .tag(peer.ip)
                                     }
@@ -704,6 +711,7 @@ struct RouteEditorSheet: View {
         .task {
             peers = await RouteManager.shared.listTailscalePeers()
             vpnLinks = await RouteManager.shared.listVPNLinks()
+            selectableLinks = await RouteManager.shared.selectableVPNLinks()
         }
     }
 
@@ -711,7 +719,7 @@ struct RouteEditorSheet: View {
     /// tunnel. Selecting a specific one pins the route to that interface.
     @ViewBuilder
     private var vpnPickerField: some View {
-        let selectable = vpnLinks.filter { !$0.isTailscale }
+        let selectable = selectableLinks
         formField(label: "VPN", required: false) {
             if selectable.isEmpty {
                 HStack(alignment: .top, spacing: 6) {
@@ -728,12 +736,15 @@ struct RouteEditorSheet: View {
                     get: { selectedVPNInterface },
                     set: { iface in
                         selectedVPNInterface = iface
-                        vpnProductHint = vpnLinks.first(where: { $0.interface == iface })?.label ?? ""
+                        vpnProductHint = selectableLinks.first(where: { $0.link.interface == iface })?.link.label ?? ""
                     }
                 )) {
                     Text("Primary VPN (automatic)").tag("")
-                    ForEach(selectable) { link in
-                        Text("\(link.label) · \(link.interface)").tag(link.interface)
+                    ForEach(selectable, id: \.link.interface) { entry in
+                        Text(entry.isLive
+                             ? "\(entry.link.label) · \(entry.link.interface)"
+                             : "\(entry.link.label) · \(entry.link.interface) — not connected")
+                            .tag(entry.link.interface)
                     }
                 }
                 .pickerStyle(.menu)

--- a/Tests/VPNBypassTests/GatewayDiscoveryTests.swift
+++ b/Tests/VPNBypassTests/GatewayDiscoveryTests.swift
@@ -1,0 +1,92 @@
+// GatewayDiscoveryTests.swift
+// Coverage for what Custom Routes can OFFER as an egress.
+//
+// Two gaps this locks down:
+//
+// 1. Tailscale peers were listed undifferentiated. On a real tailnet only a small minority
+//    advertise themselves as exit nodes (1 of 17 on the machine this was found on), and that
+//    is the only peer class that can carry general internet traffic without extra setup — so
+//    a flat list of every device gave no way to tell which choice could possibly work.
+//
+// 2. Tunnels were enumerated live only, and live enumeration reports a tunnel ONLY while it
+//    is up. A VPN you were not currently connected to could therefore never be selected,
+//    which made it impossible to pre-configure a route for a VPN you use occasionally.
+
+import XCTest
+@testable import VPNBypassCore
+
+@MainActor
+final class GatewayDiscoveryTests: XCTestCase {
+
+    private func peer(_ name: String, _ ip: String, online: Bool, exit: Bool) -> RouteManager.TailscalePeer {
+        RouteManager.TailscalePeer(name: name, ip: ip, online: online, exitNodeCapable: exit)
+    }
+
+    /// Exit-capable peers must sort to the top, then online ones — otherwise the one usable
+    /// choice is buried in a long alphabetical list of phones and offline boxes.
+    func testExitCapablePeersSortFirstThenOnline() {
+        let sorted = [
+            peer("alpha", "100.64.0.1", online: true, exit: false),
+            peer("zulu", "100.64.0.2", online: false, exit: true),
+            peer("bravo", "100.64.0.3", online: false, exit: false),
+            peer("mike", "100.64.0.4", online: true, exit: true),
+        ].sorted { a, b in
+            if a.exitNodeCapable != b.exitNodeCapable { return a.exitNodeCapable }
+            if a.online != b.online { return a.online }
+            return a.name.lowercased() < b.name.lowercased()
+        }
+        XCTAssertEqual(sorted.map(\.name), ["mike", "zulu", "alpha", "bravo"])
+    }
+
+    func testPeerCarriesExitCapability() {
+        let p = peer("MacMini", "100.95.230.41", online: true, exit: true)
+        XCTAssertTrue(p.exitNodeCapable)
+        XCTAssertFalse(peer("phone", "100.64.0.9", online: false, exit: false).exitNodeCapable)
+    }
+
+    // MARK: - Remembered tunnels
+
+    /// A tunnel seen once must remain selectable after it disconnects.
+    func testRememberedLinksSurviveDisconnect() async {
+        let rm = RouteManager.shared
+        let saved = rm.config.rememberedVPNLinks
+        defer { rm.config.rememberedVPNLinks = saved }
+
+        rm.config.rememberedVPNLinks = [
+            .init(interface: "utun7", label: "WireGuard"),
+            .init(interface: "utun9", label: "GlobalProtect"),
+        ]
+        let offered = await rm.selectableVPNLinks()
+        let names = Set(offered.map(\.link.interface))
+        XCTAssertTrue(names.contains("utun7"), "a VPN that is not connected must still be offerable")
+        XCTAssertTrue(names.contains("utun9"))
+        // Nothing in the test environment is live, so all entries report isLive == false.
+        XCTAssertTrue(offered.allSatisfy { $0.link.interface.hasPrefix("utun") })
+    }
+
+    /// Remembered entries must not duplicate a live one.
+    func testNoDuplicateBetweenLiveAndRemembered() async {
+        let rm = RouteManager.shared
+        let saved = rm.config.rememberedVPNLinks
+        defer { rm.config.rememberedVPNLinks = saved }
+        rm.config.rememberedVPNLinks = [.init(interface: "utun3", label: "X"),
+                                        .init(interface: "utun3", label: "X")]
+        let offered = await rm.selectableVPNLinks()
+        let utun3 = offered.filter { $0.link.interface == "utun3" }
+        XCTAssertLessThanOrEqual(utun3.count, 1, "an interface must appear at most once")
+    }
+
+    /// Config round-trips remembered links (decodeIfPresent — old configs unaffected).
+    func testRememberedLinksRoundTripThroughConfig() throws {
+        var cfg = RouteManager.Config()
+        cfg.rememberedVPNLinks = [.init(interface: "utun9", label: "GlobalProtect")]
+        let data = try JSONEncoder().encode(cfg)
+        let back = try JSONDecoder().decode(RouteManager.Config.self, from: data)
+        XCTAssertEqual(back.rememberedVPNLinks, cfg.rememberedVPNLinks)
+
+        // A config written before this field existed must still decode.
+        let legacy = "{\"routingMode\":\"bypass\"}".data(using: .utf8)!
+        let old = try JSONDecoder().decode(RouteManager.Config.self, from: legacy)
+        XCTAssertTrue(old.rememberedVPNLinks.isEmpty)
+    }
+}


### PR DESCRIPTION
Audit of what Custom Routes can actually offer as an egress, after the question "can I pick a Tailscale exit node, or any other VPN I use?".

**1. Tailscale peers were undifferentiated.** On a real tailnet only a small minority advertise as exit nodes — **1 of 17** on the machine tested — and that is the only peer class that can carry general internet traffic without extra setup. The picker now reads `ExitNodeOption`, marks those peers `· exit node`, and sorts exit-capable → online → alphabetical.

**2. Tunnels were live-only.** Live enumeration reports a tunnel *only while it is up*, so a VPN you were not connected to could never be selected — you could not pre-configure a route for a VPN you use occasionally. Tunnels are now remembered once seen (`Config.rememberedVPNLinks`, `decodeIfPresent` so old configs are unaffected) and offered alongside live ones, labelled **not connected**.

5 tests · `958 tests, 0 failures`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - VPN route selection now includes previously detected tunnels, even when disconnected.
  - Disconnected tunnels are clearly labeled “not connected.”
  - Tailscale peers that support exit-node routing are identified and prioritized.
  - VPN link selections are preserved across configuration saves and upgrades.

- **Bug Fixes**
  - Prevented duplicate entries when remembered and currently available tunnels overlap.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->