### PR TITLE
fix: exclude non-comparable table entries from the route snapshot (#69)

### DIFF
--- a/Helper/HelperTool.swift
+++ b/Helper/HelperTool.swift
@@ -295,9 +295,7 @@ class HelperTool: NSObject, HelperProtocol {
         guard let table = RouteKernel.currentTable() else { return [:] }
         var index: [String: RouteKernel.KernelRoute] = [:]
         for route in table {
-            guard route.flags & RTF_WASCLONED == 0,
-                  route.flags & RTF_REJECT == 0,
-                  route.flags & RTF_BLACKHOLE == 0 else { continue }
+            guard RouteKernel.isComparableEntry(route.flags) else { continue }
             index[route.destinationString] = route
         }
         return index

--- a/Sources/VPNBypassCore/RouteKernel.swift
+++ b/Sources/VPNBypassCore/RouteKernel.swift
@@ -217,6 +217,30 @@ public enum RouteKernel {
         return routes
     }
 
+    /// Whether a table entry may be compared against a route we are about to install.
+    ///
+    /// Every exclusion here is a way the snapshot could otherwise answer "already correct"
+    /// about a DIFFERENT route than the one being installed — which silently skips a needed
+    /// write and leaves the bypass not working, with no error anywhere.
+    ///
+    /// - `RTF_WASCLONED`: kernel-minted clone of a parent route, expires on its own.
+    /// - `RTF_LLINFO`: an ARP entry, not a route. It carries an AF_LINK gateway and shares a
+    ///   destination with real routes, so it can shadow one in a destination-keyed index.
+    /// - `RTF_IFSCOPE`: bound to one interface, so it does NOT serve ordinary unbound traffic
+    ///   and is invisible to the lookups our routes must win. It shares the destination string
+    ///   with the unscoped route (this machine carries a scoped default alongside the real
+    ///   one), so without this it would overwrite the entry we actually needed to compare.
+    /// - `RTF_REJECT` / `RTF_BLACKHOLE`: placeholders that drop traffic rather than carry it.
+    /// - not `RTF_UP`: a down route carries nothing.
+    public static func isComparableEntry(_ flags: Int32) -> Bool {
+        flags & RTF_UP != 0
+            && flags & RTF_WASCLONED == 0
+            && flags & RTF_LLINFO == 0
+            && flags & RTF_IFSCOPE == 0
+            && flags & RTF_REJECT == 0
+            && flags & RTF_BLACKHOLE == 0
+    }
+
     /// Reads the live IPv4 routing table via sysctl — silent and unprivileged.
     public static func currentTable() -> [KernelRoute]? {
         var mib: [Int32] = [CTL_NET, PF_ROUTE, 0, AF_INET, NET_RT_DUMP, 0]

--- a/Tests/VPNBypassTests/RouteKernelTests.swift
+++ b/Tests/VPNBypassTests/RouteKernelTests.swift
@@ -160,3 +160,46 @@ final class RouteKernelTests: XCTestCase {
         XCTAssertNil(RouteKernel.ipv4ToUInt32(""))
     }
 }
+
+// MARK: - Snapshot comparability (issue #69, requirement 4)
+
+extension RouteKernelTests {
+
+    /// A scoped route shares its destination STRING with the unscoped one — this machine
+    /// carries `default … en8` scoped alongside the real default. In a destination-keyed
+    /// snapshot the scoped entry would overwrite the one we actually need to compare against,
+    /// and the comparison could then answer "already correct" about a route that does not
+    /// serve ordinary traffic — silently skipping a write the bypass depends on.
+    func testScopedRoutesAreNotComparable() {
+        XCTAssertFalse(RouteKernel.isComparableEntry(RTF_UP | RTF_STATIC | RTF_IFSCOPE))
+    }
+
+    /// ARP entries are not routes: they carry an AF_LINK gateway and share destinations with
+    /// real routes, so they can shadow one in the index.
+    func testARPEntriesAreNotComparable() {
+        XCTAssertFalse(RouteKernel.isComparableEntry(RTF_UP | RTF_LLINFO))
+    }
+
+    func testClonedRejectBlackholeAndDownEntriesAreNotComparable() {
+        XCTAssertFalse(RouteKernel.isComparableEntry(RTF_UP | RTF_WASCLONED))
+        XCTAssertFalse(RouteKernel.isComparableEntry(RTF_UP | RTF_REJECT))
+        XCTAssertFalse(RouteKernel.isComparableEntry(RTF_UP | RTF_BLACKHOLE))
+        XCTAssertFalse(RouteKernel.isComparableEntry(RTF_STATIC), "a down route carries nothing")
+    }
+
+    /// The routes we actually install must remain comparable, or every apply would rewrite
+    /// everything and the zero-churn property would be lost.
+    func testOurOwnRoutesRemainComparable() {
+        XCTAssertTrue(RouteKernel.isComparableEntry(RTF_UP | RTF_STATIC | RTF_GATEWAY | RTF_HOST | RTF_PROTO1))
+        XCTAssertTrue(RouteKernel.isComparableEntry(RTF_UP | RTF_STATIC | RTF_PROTO1))
+    }
+
+    /// The live table must still yield usable entries after filtering — a filter that
+    /// excluded everything would silently turn every apply back into a blind write.
+    func testLiveTableStillYieldsComparableEntries() throws {
+        let table = try XCTUnwrap(RouteKernel.currentTable())
+        let comparable = table.filter { RouteKernel.isComparableEntry($0.flags) }
+        XCTAssertFalse(comparable.isEmpty, "a live machine must have comparable routes")
+        XCTAssertTrue(comparable.allSatisfy { $0.flags & RTF_IFSCOPE == 0 })
+    }
+}


### PR DESCRIPTION
Completes the route-identity requirement from #69.

v4.0.0 already replaced the per-route `route -n get` forks with a single silent `NET_RT_DUMP` snapshot (and went further — it removed the *write* forks too). But its filter covered only cloned/reject/blackhole, and two of the remaining omissions are real:

- **`RTF_IFSCOPE`** — a scoped route shares its **destination string** with the unscoped one, so in a destination-keyed index it *overwrote the entry we needed*. This machine carries **three** default routes, two scoped (`en0`, `utun4`). The comparison could therefore answer "already correct" about a route that does not serve ordinary unbound traffic, silently skipping a write the bypass depends on — precisely the failure mode #69 cites when arguing against a cache.
- **`RTF_LLINFO`** — ARP entries are not routes; they carry an AF_LINK gateway and share destinations with real routes.
- **`RTF_UP`** now required — a down route carries nothing.

Centralised as `RouteKernel.isComparableEntry` with the reasoning recorded per flag.

6 tests, including one asserting the live table still yields comparable entries — a filter that excluded everything would silently turn every apply back into a blind write.

`958 tests, 0 failures`

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route snapshot comparisons by consistently excluding inactive, scoped, ARP, cloned, reject, and blackhole routes.
  * Ensured valid installed routes remain included when reading live routing tables.

* **Tests**
  * Added coverage for route filtering and preservation of comparable routing entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->