### PR TITLE
fix: pace kernel route writes and settle reconnect applies

### DIFF
--- a/Helper/HelperTool.swift
+++ b/Helper/HelperTool.swift
@@ -239,6 +239,10 @@ class HelperTool: NSObject, HelperProtocol {
 
     private var routeSocketFD: Int32 = -1
     private var routeSeq: Int32 = 0
+    /// Paces write bursts so other processes' routing sockets never overflow mid request/reply
+    /// (a lost reply is what the corporate VPN client misreads as "gateway route removed" — see
+    /// RouteKernel.WritePacer). Only ever touched on `routeQueue`, like the socket itself.
+    private var writePacer = RouteKernel.WritePacer()
 
     /// Writes one routing message; returns nil on success or the errno on failure.
     private func routeSocketPerform(type: Int32, spec: RouteKernel.Spec) -> Int32? {
@@ -256,6 +260,11 @@ class HelperTool: NSObject, HelperProtocol {
         }
         let written = msg.withUnsafeBytes { raw in
             write(routeSocketFD, raw.baseAddress, raw.count)
+        }
+        // Failed writes are broadcast to listeners exactly like successful ones, so every
+        // attempt counts toward the pacing budget.
+        if writePacer.recordWrite(nowNS: DispatchTime.now().uptimeNanoseconds) {
+            usleep(writePacer.pauseMicroseconds)
         }
         if written == msg.count { return nil }
         let err = errno

--- a/Helper/HelperTool.swift
+++ b/Helper/HelperTool.swift
@@ -241,8 +241,11 @@ class HelperTool: NSObject, HelperProtocol {
     private var routeSeq: Int32 = 0
     /// Paces write bursts so other processes' routing sockets never overflow mid request/reply
     /// (a lost reply is what the corporate VPN client misreads as "gateway route removed" — see
-    /// RouteKernel.WritePacer). Only ever touched on `routeQueue`, like the socket itself.
-    private var writePacer = RouteKernel.WritePacer()
+    /// RouteKernel.WritePacer). STATIC like `routeQueue` and for the same reason: a fresh
+    /// `HelperTool` is created per XPC connection, and a per-instance pacer would give each
+    /// connection its own budget — alternating writes from two connections could then exceed a
+    /// chunk with no pause. One shared pacer, only ever touched on `routeQueue`.
+    private static var writePacer = RouteKernel.WritePacer()
 
     /// Writes one routing message; returns nil on success or the errno on failure.
     private func routeSocketPerform(type: Int32, spec: RouteKernel.Spec) -> Int32? {
@@ -263,8 +266,8 @@ class HelperTool: NSObject, HelperProtocol {
         }
         // Failed writes are broadcast to listeners exactly like successful ones, so every
         // attempt counts toward the pacing budget.
-        if writePacer.recordWrite(nowNS: DispatchTime.now().uptimeNanoseconds) {
-            usleep(writePacer.pauseMicroseconds)
+        if Self.writePacer.recordWrite(nowNS: DispatchTime.now().uptimeNanoseconds) {
+            usleep(Self.writePacer.pauseMicroseconds)
         }
         if written == msg.count { return nil }
         let err = errno

--- a/Helper/Info.plist
+++ b/Helper/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleName</key>
 	<string>VPNBypassHelper</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>12</string>
 	<key>SMAuthorizedClients</key>
 	<array>
 		<string>identifier "com.geiserx.vpn-bypass"</string>

--- a/Sources/VPNBypassCore/HelperManager.swift
+++ b/Sources/VPNBypassCore/HelperManager.swift
@@ -721,8 +721,13 @@ let timeout = xpcTimeout + Double(routes.count) * 0.6
         let dictEntries = entries.map { ["domain": $0.domain, "ip": $0.ip] }
 
         let connection = getOrCreateConnection()
-        let fallback: (Bool, String?) = (false, "XPC timeout after \(Int(xpcTimeout))s")
-        let result = await withXPCDeadline(seconds: xpcTimeout, fallback: fallback) { once in
+        // Hosts updates queue on the helper's serial mutation queue BEHIND any in-flight route
+        // batch, and batches are now deliberately paced (a couple of seconds for hundreds of
+        // routes) — the flat 10s deadline was observed timing out exactly there. 30s covers the
+        // worst paced batch with margin; the helper stays responsive either way.
+        let hostsTimeout: TimeInterval = max(xpcTimeout, 30)
+        let fallback: (Bool, String?) = (false, "XPC timeout after \(Int(hostsTimeout))s")
+        let result = await withXPCDeadline(seconds: hostsTimeout, fallback: fallback) { once in
             let proxy = connection.remoteObjectProxyWithErrorHandler { error in
                 once.complete((false, "XPC error: \(error.localizedDescription)"))
             } as? HelperProtocol

--- a/Sources/VPNBypassCore/HelperProtocol.swift
+++ b/Sources/VPNBypassCore/HelperProtocol.swift
@@ -112,7 +112,13 @@ struct HelperConstants {
     // replaces only as a last resort. Route/hosts mutations are also serialised across XPC
     // connections (concurrent handlers were producing simultaneous /sbin/route processes), and the
     // helper finally emits os_log records. Bumped from 1.8.0 so installed helpers pick this up.
-    static let helperVersion = "2.0.0"
+    // 2.1.0: kernel writes are PACED (RouteKernel.WritePacer). Every RTM write is broadcast to
+    // every open routing socket and the kernel silently drops messages for a full receive
+    // buffer, so an uninterrupted several-hundred-message batch could swallow the reply of a
+    // concurrent `route -n get` — observed as GlobalProtect's gateway-route read timing out
+    // seconds after our batch and tearing the tunnel down. A 200ms pause every 32 writes keeps
+    // any listener's backlog under one buffer. Bumped so installed helpers pick this up.
+    static let helperVersion = "2.1.0"
     static let bundleID = "com.geiserx.vpnbypass.helper"
     static let hostMarkerStart = "# VPN-BYPASS-MANAGED - START"
     static let hostMarkerEnd = "# VPN-BYPASS-MANAGED - END"

--- a/Sources/VPNBypassCore/RerouteDecider.swift
+++ b/Sources/VPNBypassCore/RerouteDecider.swift
@@ -18,6 +18,8 @@
 // unit-testable without driving the @MainActor RouteManager, its subprocesses, or
 // real kernel routes. No @MainActor, no I/O — inputs in, action out.
 
+import Foundation
+
 enum RerouteDecider {
 
     /// What checkVPNStatus (or the latch-retry chain) should do this pass.
@@ -68,5 +70,26 @@ enum RerouteDecider {
 
         let canRunNow = !isLoading && !isApplyingRoutes && !cooldownActive && hasGateway
         return canRunNow ? .reroute : .latch
+    }
+}
+
+/// Pure delay policy for the reconnect settle gate (see RouteManager.reconnectSettleTask).
+///
+/// The moment a VPN tunnel (re)appears is when its client is most fragile — GlobalProtect
+/// re-checks its gateway route repeatedly for the first half minute after a restore, and a
+/// full apply fired into that window turned one external drop into a minutes-long flap loop.
+/// Warm restores (bypass routes still installed and working) can wait comfortably; a cold
+/// start (nothing installed, the user is waiting for their bypasses) waits less; and once a
+/// flap storm has cancelled the wait `maxDeferrals` times, the delay collapses so the apply
+/// can never be starved forever — by then the paced helper writes are the remaining shield.
+enum ReconnectSettle {
+    static let warmDelay: TimeInterval = 20
+    static let coldDelay: TimeInterval = 10
+    static let cappedDelay: TimeInterval = 5
+    static let maxDeferrals = 5
+
+    static func delay(deferrals: Int, hasInstalledRoutes: Bool) -> TimeInterval {
+        if deferrals >= maxDeferrals { return cappedDelay }
+        return hasInstalledRoutes ? warmDelay : coldDelay
     }
 }

--- a/Sources/VPNBypassCore/RouteKernel.swift
+++ b/Sources/VPNBypassCore/RouteKernel.swift
@@ -3,13 +3,22 @@
 // and the privileged helper, and unit-tested from the app test target.
 //
 // WHY THIS EXISTS — the traced root cause of the VPN instability this app used to trigger was
-// never the route *writes* themselves (the corporate client debounces those and demonstrably
-// tolerates hundreds); it was SUBPROCESS CONTENTION: every `/sbin/route` invocation is a
-// fork+exec that opens its own routing socket and blocks with no timeout. Stacked invocations
-// starved other processes' route operations — including the VPN client's own periodic gateway
-// route *read*, whose timeout the client misreads as "my gateway route was removed" and tears
-// the tunnel down. Writing rt_msghdr structs to one owned socket makes that starvation
-// structurally impossible: no forks, one in-flight request, errno straight from write(2).
+// not route *writes* in steady state (the corporate client debounces those and demonstrably
+// tolerates hundreds); it was starving the client's periodic gateway-route *read*, whose
+// timeout the client misreads as "my gateway route was removed" and tears the tunnel down.
+// That starvation has two forms, both closed here:
+//   1. SUBPROCESS CONTENTION (v3): every `/sbin/route` invocation is a fork+exec that opens
+//      its own routing socket and blocks with no timeout; stacked invocations starved other
+//      processes' route operations. Fixed by writing rt_msghdr structs to one owned socket —
+//      no forks, one in-flight request, errno straight from write(2).
+//   2. RECEIVE-BUFFER OVERFLOW (v4.6 follow-up): every RTM write, failed ones included, is
+//      broadcast to every open routing socket, and the kernel silently DROPS messages for a
+//      socket whose small receive buffer is full. An uninterrupted several-hundred-message
+//      batch can therefore swallow the reply of a concurrent `route -n get` request/reply
+//      exchange — observed live as the VPN client's read timing out seconds after our batch,
+//      exactly while it was re-checking its gateway after a restore. Fixed by WritePacer
+//      (end of this file): a short pause every few dozen writes bounds any listener's
+//      backlog to well under one buffer.
 //
 // Layout notes that differ from other BSDs (the classic porting traps):
 //   - sockaddr alignment inside a routing message is FOUR bytes on macOS, not sizeof(long).
@@ -335,5 +344,51 @@ public enum RouteKernel {
             mask = (mask << 8) | UInt32(byte)
         }
         return mask.nonzeroBitCount
+    }
+}
+
+// MARK: - Write pacing
+
+extension RouteKernel {
+    /// Paces bursts of routing-socket writes so concurrent readers never lose messages.
+    ///
+    /// Every RTM write is broadcast to every open routing socket on the system, and a routing
+    /// socket's receive buffer is small (8 KB by default — roughly fifty messages). When a
+    /// socket's buffer is full the kernel silently drops further messages for it, which breaks
+    /// any process mid request/reply on its own routing socket: most critically the corporate
+    /// VPN client's forked gateway-route read, whose lost reply it misreads as "my gateway
+    /// route was removed" and tears the tunnel down (the #65 failure, resurfacing via bursts
+    /// instead of forks). Pausing after every `chunkSize` writes keeps any listener's backlog
+    /// well under one buffer and gives readers a drain window. Single interactive operations
+    /// never reach the chunk boundary, so they stay instant; a burst separated by more than
+    /// `idleResetNanoseconds` from the previous write starts a fresh chunk count.
+    ///
+    /// Pure value type — the caller supplies monotonic timestamps and performs the actual
+    /// sleep, so the pacing decision is unit-testable.
+    public struct WritePacer {
+        public let chunkSize: Int
+        public let pauseMicroseconds: UInt32
+        public let idleResetNanoseconds: UInt64
+        private var burstCount = 0
+        private var lastWriteNS: UInt64 = 0
+
+        public init(chunkSize: Int = 32,
+                    pauseMicroseconds: UInt32 = 200_000,
+                    idleResetNanoseconds: UInt64 = 1_000_000_000) {
+            self.chunkSize = chunkSize
+            self.pauseMicroseconds = pauseMicroseconds
+            self.idleResetNanoseconds = idleResetNanoseconds
+        }
+
+        /// Record one write occurring at `nowNS` (monotonic clock). Returns true when the
+        /// caller should pause for `pauseMicroseconds` before issuing the next write.
+        public mutating func recordWrite(nowNS: UInt64) -> Bool {
+            if lastWriteNS != 0 && nowNS &- lastWriteNS > idleResetNanoseconds {
+                burstCount = 0
+            }
+            lastWriteNS = nowNS
+            burstCount += 1
+            return burstCount % chunkSize == 0
+        }
     }
 }

--- a/Sources/VPNBypassCore/RouteKernel.swift
+++ b/Sources/VPNBypassCore/RouteKernel.swift
@@ -375,6 +375,9 @@ extension RouteKernel {
         public init(chunkSize: Int = 32,
                     pauseMicroseconds: UInt32 = 200_000,
                     idleResetNanoseconds: UInt64 = 1_000_000_000) {
+            // recordWrite computes `burstCount % chunkSize` — a non-positive chunk would trap
+            // (or never pause); this is a programmer-error boundary, not runtime input.
+            precondition(chunkSize > 0, "WritePacer chunkSize must be positive")
             self.chunkSize = chunkSize
             self.pauseMicroseconds = pauseMicroseconds
             self.idleResetNanoseconds = idleResetNanoseconds

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -1627,6 +1627,13 @@ final class RouteManager: ObservableObject {
         let desiredPairs = Set(routesToAdd.map { "\($0.destination)|\($0.gateway)" })
         let activePairs = Set(activeRoutes.map { "\($0.destination)|\($0.gateway)" })
         if Self.shouldSkipReapply(desiredPairs: desiredPairs, activePairs: activePairs, forceReassert: forceReassert) {
+            // active == desired means no graced orphan is outstanding, so any grace history
+            // left in the map belongs to destinations that are desired again (or gone) and
+            // must be forgiven here — this return skips commitAppliedRoutes, where that
+            // forgiveness normally happens. Without it, a retain → restore → rotate-out
+            // sequence would age the route from its ORIGINAL timestamp and delete it
+            // immediately instead of granting a fresh TTL.
+            orphanFirstSeen.removeAll()
             log(.info, "Routes already current (\(activePairs.count)) — skipping re-apply to avoid route-table churn")
             lastUpdate = Date()
             return
@@ -1760,6 +1767,8 @@ final class RouteManager: ObservableObject {
         let desiredPairs = Set(routesToAdd.map { "\($0.destination)|\($0.gateway)" })
         let activePairs = Set(activeRoutes.map { "\($0.destination)|\($0.gateway)" })
         if Self.shouldSkipReapply(desiredPairs: desiredPairs, activePairs: activePairs, forceReassert: forceReassert) {
+            // Same grace-history forgiveness as the classic skip path (see there for why).
+            orphanFirstSeen.removeAll()
             log(.info, "Custom routes already current (\(activePairs.count)) — skipping re-apply to avoid route-table churn")
             lastUpdate = Date()
             return true

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -73,6 +73,20 @@ final class RouteManager: ObservableObject {
     var pendingReroute = false
     var pendingRerouteReason: String?
     private var lastTailscaleSelfFingerprint: String?
+    /// Reconnect settle gate. The moment a VPN tunnel (re)appears is exactly when its client is
+    /// most fragile — GlobalProtect re-checks its gateway route repeatedly for the first half
+    /// minute after a restore, and a full apply fired into that window (hundreds of broadcast
+    /// route events) knocked the tunnel straight back down, turning one external drop into a
+    /// minutes-long flap loop (three drops in as many minutes, each seconds after our batch).
+    /// Bypass routes are KEPT across a drop, so there is no urgency to re-apply: wait for the
+    /// tunnel to hold before touching the kernel. A drop during the wait cancels the pending
+    /// apply and counts a deferral, so a flap storm coalesces into ONE apply once things hold;
+    /// after `ReconnectSettle.maxDeferrals` the delay shortens so we can never starve.
+    private var reconnectSettleTask: Task<Void, Never>?
+    private var reconnectDeferrals = 0
+    /// First-seen timestamps for routes that dropped out of the desired set during an
+    /// auto-triggered apply (DNS rotation, mostly). See `orphanGraceDecision`.
+    private var orphanFirstSeen: [String: Date] = [:]
     
     
     /// Set once in init from the SAME directory as `configURL`, so it follows the under-test
@@ -390,7 +404,30 @@ final class RouteManager: ObservableObject {
         }
     }
     
+    /// Single-flight gate for `checkVPNStatusCore`. The core awaits freely (detection passes,
+    /// a 1.5s flap recheck, route teardown), and it is triggered from several sources at once
+    /// during churn — the path monitor, the process poller, refreshStatus. Overlapping runs
+    /// each captured the same `wasVPNConnected` and each committed the same transition:
+    /// observed live as THREE "VPN disconnected" teardowns and three notifications for one
+    /// disconnect, four seconds apart. One run at a time; anything that fires mid-run queues
+    /// exactly one trailing re-check so a state change during the run is never missed.
+    private var vpnStatusCheckInFlight = false
+    private var vpnStatusRecheckQueued = false
+
     func checkVPNStatus() async {
+        if vpnStatusCheckInFlight {
+            vpnStatusRecheckQueued = true
+            return
+        }
+        vpnStatusCheckInFlight = true
+        defer { vpnStatusCheckInFlight = false }
+        repeat {
+            vpnStatusRecheckQueued = false
+            await checkVPNStatusCore()
+        } while vpnStatusRecheckQueued
+    }
+
+    private func checkVPNStatusCore() async {
         let wasVPNConnected = isVPNConnected
         let oldInterface = vpnInterface
         // Captured BEFORE re-detection below overwrites it, so a same-interface gateway change is
@@ -450,13 +487,19 @@ final class RouteManager: ObservableObject {
             if let lastUpdate = lastUpdate, Date().timeIntervalSince(lastUpdate) < 5 {
                 log(.info, "Skipping duplicate route application (applied \(Int(Date().timeIntervalSince(lastUpdate)))s ago)")
             } else {
-                log(.success, "VPN connected via \(interface ?? "unknown") (\(detectedType?.rawValue ?? "unknown type")), applying routes...")
+                // Settle gate: never fire the apply into the tunnel's fragile post-(re)connect
+                // window — see reconnectSettleTask. The notification still goes out now (the
+                // VPN *is* connected); only our kernel writes wait.
+                let delay = ReconnectSettle.delay(deferrals: reconnectDeferrals,
+                                                  hasInstalledRoutes: !activeRoutes.isEmpty)
+                log(.success, "VPN connected via \(interface ?? "unknown") (\(detectedType?.rawValue ?? "unknown type")) — applying routes in \(Int(delay))s once the tunnel settles")
                 NotificationManager.shared.notifyVPNConnected(interface: interface ?? "unknown")
-                
-                // Show loading indicator while applying routes
-                isLoading = true
-                await applyAllRoutes()
-                isLoading = false
+                reconnectSettleTask?.cancel()
+                reconnectSettleTask = Task { [weak self] in
+                    try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                    guard !Task.isCancelled, let self else { return }
+                    await self.runSettledApply()
+                }
             }
         }
         
@@ -540,6 +583,15 @@ final class RouteManager: ObservableObject {
         
         if !isVPNConnected && wasVPNConnected {
             log(.warning, "VPN disconnected (was: \(oldInterface ?? "unknown"))")
+            // The tunnel dropped during a settle wait: cancel the pending apply (routes are
+            // kept, nothing is lost) and count the deferral so a long flap storm eventually
+            // shortens the wait instead of starving forever.
+            if reconnectSettleTask != nil {
+                reconnectSettleTask?.cancel()
+                reconnectSettleTask = nil
+                reconnectDeferrals += 1
+                log(.info, "Settle-gated apply cancelled — VPN dropped during the wait (deferral \(reconnectDeferrals))")
+            }
             cancelAllRetries()
             // Drop any latched re-route and stop its retry chain — there's nothing to
             // re-route once the VPN is gone. Prevents an orphaned retry Task and a
@@ -596,6 +648,24 @@ final class RouteManager: ObservableObject {
         }
     }
     
+    /// The settle-gated apply scheduled by checkVPNStatusCore. Every precondition is
+    /// re-validated at fire time — the world may have moved during the wait. The cancellation
+    /// re-check closes a supersede race: an old task that passed its post-sleep check right as
+    /// a disconnect cancelled it must not run, and must not clear a newer task's reference.
+    private func runSettledApply() async {
+        guard !Task.isCancelled else { return }
+        reconnectSettleTask = nil
+        guard isVPNConnected, config.autoApplyOnVPN, !isLoading, !isApplyingRoutes,
+              HelperManager.shared.isHelperInstalled else {
+            log(.info, "Settle-gated apply skipped — preconditions changed during the wait")
+            return
+        }
+        reconnectDeferrals = 0
+        isLoading = true
+        await applyAllRoutes(orphanGrace: true)
+        isLoading = false
+    }
+
     private func detectVPNInterface() async -> (connected: Bool, interface: String?, type: VPNType?) {
         // First check for specific VPN processes to help identify type
         let runningVPNType = await detectRunningVPNProcess()
@@ -1287,14 +1357,17 @@ final class RouteManager: ObservableObject {
         schemaVersion >= 2 && routingMode == .custom
     }
 
-    /// Apply all routes — acquires exclusive gate, skips if another operation is running
-    func applyAllRoutes() async {
+    /// Apply all routes — acquires exclusive gate, skips if another operation is running.
+    /// `orphanGrace` is passed by AUTO-triggered applies only (the reconnect settle path):
+    /// it defers deleting routes that merely rotated out of DNS. User-initiated applies keep
+    /// immediate deletion so an explicit removal takes effect at once.
+    func applyAllRoutes(orphanGrace: Bool = false) async {
         guard acquireRouteOperation() else {
             log(.info, "Apply skipped: route operation in progress")
             return
         }
         defer { releaseRouteOperation() }
-        await applyAllRoutesInternal(sendNotification: false)
+        await applyAllRoutesInternal(sendNotification: false, orphanGrace: orphanGrace)
     }
 
     /// Apply all routes and send notification (called from Refresh button)
@@ -1376,7 +1449,8 @@ final class RouteManager: ObservableObject {
 
     /// Internal — gate-free, callers must hold the route operation lock.
     /// Checks routeEpoch before committing to detect preemption by removeAllRoutes.
-    private func applyAllRoutesInternal(sendNotification: Bool, forceReassert: Bool = false) async {
+    private func applyAllRoutesInternal(sendNotification: Bool, forceReassert: Bool = false,
+                                        orphanGrace: Bool = false) async {
         let epoch = routeEpoch
 
         guard let gateway = localGateway else {
@@ -1580,7 +1654,7 @@ final class RouteManager: ObservableObject {
             return
         }
 
-        let committed = await commitAppliedRoutes(routesToAdd: routesToAdd, allSourceEntries: allSourceEntries, batchFailedDests: batchFailedDests, epoch: epoch, logLabel: "")
+        let committed = await commitAppliedRoutes(routesToAdd: routesToAdd, allSourceEntries: allSourceEntries, batchFailedDests: batchFailedDests, epoch: epoch, logLabel: "", orphanGrace: orphanGrace)
         guard committed else { return }
 
         let confirmedUniqueCount = uniqueRouteCount
@@ -2112,12 +2186,59 @@ final class RouteManager: ObservableObject {
     /// "Cache " for the cached fast-path (log prefixing only). Runs on the class
     /// @MainActor; the epoch-guard→commit window stays await-free (updateHostsFile
     /// awaits only after the commit).
+    /// Orphan-grace tuning: how long a route that fell out of the desired set is kept before
+    /// deletion (rotating CDN answers usually return well within this) and a hard cap on how
+    /// many graced routes may accumulate (oldest evicted first past the cap).
+    static let orphanGraceTTL: TimeInterval = 30 * 60
+    static let orphanGraceCap = 400
+
+    struct OrphanGraceOutcome: Equatable {
+        var deleteNow: [String]
+        var retained: [String]
+        var updatedFirstSeen: [String: Date]
+    }
+
+    /// Pure grace decision for orphaned routes. An orphan is deleted only once it has stayed
+    /// out of the desired set for `ttl`; until then it is retained (still installed, still
+    /// tracked). History for a destination that is desired again — or gone from the orphan set
+    /// entirely — is dropped, so rotation-back costs zero kernel events. Past `cap` retained
+    /// entries, the oldest are evicted to deleteNow so the graced set stays bounded. Outputs
+    /// are sorted for determinism.
+    nonisolated static func orphanGraceDecision(orphaned: Set<String>, applied: Set<String>,
+                                                firstSeen: [String: Date], now: Date,
+                                                ttl: TimeInterval, cap: Int) -> OrphanGraceOutcome {
+        var seen = firstSeen.filter { !applied.contains($0.key) && orphaned.contains($0.key) }
+        var deleteNow: [String] = []
+        var retained: [String] = []
+        for dest in orphaned {
+            let first = seen[dest] ?? now
+            if now.timeIntervalSince(first) >= ttl {
+                deleteNow.append(dest)
+                seen.removeValue(forKey: dest)
+            } else {
+                seen[dest] = first
+                retained.append(dest)
+            }
+        }
+        if retained.count > cap {
+            let oldestFirst = retained.sorted { (seen[$0] ?? now, $0) < (seen[$1] ?? now, $1) }
+            for dest in oldestFirst.prefix(retained.count - cap) {
+                seen.removeValue(forKey: dest)
+                deleteNow.append(dest)
+            }
+            retained = Array(oldestFirst.dropFirst(retained.count - cap))
+        }
+        return OrphanGraceOutcome(deleteNow: deleteNow.sorted(), retained: retained.sorted(),
+                                  updatedFirstSeen: seen)
+    }
+
     func commitAppliedRoutes(
         routesToAdd: [(destination: String, gateway: String, isNetwork: Bool, source: String)],
         allSourceEntries: [(destination: String, gateway: String, source: String)],
         batchFailedDests: Set<String>,
         epoch: UInt64,
-        logLabel: String
+        logLabel: String,
+        orphanGrace: Bool = false
     ) async -> Bool {
         var newRoutes: [ActiveRoute] = []
 
@@ -2143,8 +2264,36 @@ final class RouteManager: ObservableObject {
             applied: newDestinations,
             attempted: Set(routesToAdd.map { $0.destination })
         )
-        let trulyOrphanedDests = Array(stalePartition.orphaned)
+        var trulyOrphanedDests = Array(stalePartition.orphaned)
         let addFailedStaleDests = Array(stalePartition.addFailed)
+
+        // Orphan grace (auto-triggered applies in classic bypass mode only): most "orphans"
+        // are CDN IPs that merely rotated out of this resolve — 100–150 per cycle observed —
+        // and deleting then re-adding them when rotation swings back doubles the broadcast
+        // burst the tunnel client has to sit through. Deferring the delete until an IP has
+        // stayed gone for the TTL removes that churn; graced routes keep working meanwhile
+        // (they egress the stable local gateway). User-initiated applies pass
+        // orphanGrace=false, so an explicit removal still takes effect immediately.
+        if orphanGrace && config.routingMode == .bypass {
+            let outcome = Self.orphanGraceDecision(orphaned: stalePartition.orphaned,
+                                                   applied: newDestinations,
+                                                   firstSeen: orphanFirstSeen,
+                                                   now: Date(),
+                                                   ttl: Self.orphanGraceTTL,
+                                                   cap: Self.orphanGraceCap)
+            orphanFirstSeen = outcome.updatedFirstSeen
+            trulyOrphanedDests = outcome.deleteNow
+            if !outcome.retained.isEmpty {
+                let retainSet = Set(outcome.retained)
+                for route in activeRoutes where retainSet.contains(route.destination) && !newDestinations.contains(route.destination) {
+                    newRoutes.append(route)
+                }
+                log(.info, "\(logLabel)Orphan grace: \(outcome.retained.count) recently-rotated route(s) kept, delete deferred")
+            }
+        } else {
+            // Immediate-delete path: any grace history is moot once the deletes go through.
+            orphanFirstSeen.removeAll()
+        }
 
         // Truly orphaned: re-attach on failure (route is genuinely still in kernel)
         if !trulyOrphanedDests.isEmpty {

--- a/Tests/VPNBypassTests/OrphanGraceTests.swift
+++ b/Tests/VPNBypassTests/OrphanGraceTests.swift
@@ -1,0 +1,96 @@
+// OrphanGraceTests.swift
+// Coverage for the orphan-grace decision (RouteManager.orphanGraceDecision).
+//
+// The churn being eliminated: rotating CDN DNS makes 100–150 installed routes fall out of the
+// desired set on EVERY auto re-apply, and each of those deletes — plus the re-add when the IP
+// rotates back — is a broadcast routing event the tunnel client must sit through. The grace
+// contract: a fresh orphan is retained (still installed, still tracked); it is deleted only
+// after staying gone for the TTL; a destination that becomes desired again has its history
+// forgiven at zero kernel cost; and the retained set is bounded by evicting oldest-first.
+
+import XCTest
+@testable import VPNBypassCore
+
+final class OrphanGraceTests: XCTestCase {
+
+    private let ttl: TimeInterval = 1800
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+
+    /// A first-seen orphan must be retained, with its clock started at `now`.
+    func testFreshOrphanIsRetainedNotDeleted() {
+        let outcome = RouteManager.orphanGraceDecision(
+            orphaned: ["1.2.3.4"], applied: [], firstSeen: [:],
+            now: now, ttl: ttl, cap: 400
+        )
+        XCTAssertEqual(outcome.deleteNow, [])
+        XCTAssertEqual(outcome.retained, ["1.2.3.4"])
+        XCTAssertEqual(outcome.updatedFirstSeen["1.2.3.4"], now)
+    }
+
+    /// Once an orphan has stayed gone for the TTL it is deleted and its history dropped.
+    func testAgedOrphanIsDeleted() {
+        let outcome = RouteManager.orphanGraceDecision(
+            orphaned: ["1.2.3.4"], applied: [],
+            firstSeen: ["1.2.3.4": now.addingTimeInterval(-ttl)],
+            now: now, ttl: ttl, cap: 400
+        )
+        XCTAssertEqual(outcome.deleteNow, ["1.2.3.4"])
+        XCTAssertEqual(outcome.retained, [])
+        XCTAssertNil(outcome.updatedFirstSeen["1.2.3.4"])
+    }
+
+    /// An orphan still inside its TTL keeps its ORIGINAL first-seen time — the clock must not
+    /// restart on every apply, or nothing would ever age out.
+    func testRetainedOrphanKeepsOriginalClock() {
+        let earlier = now.addingTimeInterval(-600)
+        let outcome = RouteManager.orphanGraceDecision(
+            orphaned: ["1.2.3.4"], applied: [],
+            firstSeen: ["1.2.3.4": earlier],
+            now: now, ttl: ttl, cap: 400
+        )
+        XCTAssertEqual(outcome.retained, ["1.2.3.4"])
+        XCTAssertEqual(outcome.updatedFirstSeen["1.2.3.4"], earlier)
+    }
+
+    /// Rotation-back: a destination that is desired again must have its history forgiven —
+    /// no delete, no re-add, no clock left behind to mis-age it later.
+    func testReappearedDestinationHistoryIsForgiven() {
+        let outcome = RouteManager.orphanGraceDecision(
+            orphaned: [], applied: ["1.2.3.4"],
+            firstSeen: ["1.2.3.4": now.addingTimeInterval(-900)],
+            now: now, ttl: ttl, cap: 400
+        )
+        XCTAssertEqual(outcome.deleteNow, [])
+        XCTAssertEqual(outcome.retained, [])
+        XCTAssertTrue(outcome.updatedFirstSeen.isEmpty)
+    }
+
+    /// History for a destination that vanished entirely (not orphaned, not applied) must be
+    /// dropped, or the map would grow without bound.
+    func testVanishedDestinationHistoryIsPruned() {
+        let outcome = RouteManager.orphanGraceDecision(
+            orphaned: ["5.6.7.8"], applied: [],
+            firstSeen: ["9.9.9.9": now.addingTimeInterval(-100)],
+            now: now, ttl: ttl, cap: 400
+        )
+        XCTAssertNil(outcome.updatedFirstSeen["9.9.9.9"])
+        XCTAssertEqual(outcome.retained, ["5.6.7.8"])
+    }
+
+    /// Past the cap, the OLDEST graced routes are evicted to deleteNow so the retained set
+    /// stays bounded; the newest survive.
+    func testCapEvictsOldestFirst() {
+        let outcome = RouteManager.orphanGraceDecision(
+            orphaned: ["10.0.0.1", "10.0.0.2", "10.0.0.3"], applied: [],
+            firstSeen: [
+                "10.0.0.1": now.addingTimeInterval(-300),   // oldest → evicted
+                "10.0.0.2": now.addingTimeInterval(-200),
+                "10.0.0.3": now.addingTimeInterval(-100),
+            ],
+            now: now, ttl: ttl, cap: 2
+        )
+        XCTAssertEqual(outcome.deleteNow, ["10.0.0.1"])
+        XCTAssertEqual(outcome.retained, ["10.0.0.2", "10.0.0.3"])
+        XCTAssertNil(outcome.updatedFirstSeen["10.0.0.1"])
+    }
+}

--- a/Tests/VPNBypassTests/ReconnectSettleTests.swift
+++ b/Tests/VPNBypassTests/ReconnectSettleTests.swift
@@ -1,0 +1,44 @@
+// ReconnectSettleTests.swift
+// Coverage for the reconnect settle-gate delay policy (ReconnectSettle).
+//
+// The contract being locked down: a warm restore (bypass routes still installed and carrying
+// traffic) waits the full settle window; a cold start (nothing installed, the user is waiting)
+// waits less; and once a flap storm has cancelled the pending apply `maxDeferrals` times, the
+// delay collapses so the apply can never be starved indefinitely.
+
+import XCTest
+@testable import VPNBypassCore
+
+final class ReconnectSettleTests: XCTestCase {
+
+    /// Routes still installed → the apply is pure refresh, so it can wait the longest.
+    func testWarmRestoreUsesFullSettleWindow() {
+        XCTAssertEqual(ReconnectSettle.delay(deferrals: 0, hasInstalledRoutes: true),
+                       ReconnectSettle.warmDelay)
+    }
+
+    /// Nothing installed → the user is waiting for their bypasses; shorter, but still clear of
+    /// the tunnel's immediate post-connect turbulence.
+    func testColdStartWaitsLess() {
+        XCTAssertEqual(ReconnectSettle.delay(deferrals: 0, hasInstalledRoutes: false),
+                       ReconnectSettle.coldDelay)
+        XCTAssertLessThan(ReconnectSettle.coldDelay, ReconnectSettle.warmDelay)
+    }
+
+    /// Below the cap, deferrals do not change the delay — the wait simply re-arms.
+    func testDeferralsBelowCapKeepNormalDelay() {
+        XCTAssertEqual(ReconnectSettle.delay(deferrals: ReconnectSettle.maxDeferrals - 1,
+                                             hasInstalledRoutes: true),
+                       ReconnectSettle.warmDelay)
+    }
+
+    /// At the cap the delay collapses regardless of warm/cold — anti-starvation kicks in.
+    func testCapCollapsesDelay() {
+        for warm in [true, false] {
+            XCTAssertEqual(ReconnectSettle.delay(deferrals: ReconnectSettle.maxDeferrals,
+                                                 hasInstalledRoutes: warm),
+                           ReconnectSettle.cappedDelay)
+        }
+        XCTAssertLessThan(ReconnectSettle.cappedDelay, ReconnectSettle.coldDelay)
+    }
+}

--- a/Tests/VPNBypassTests/WritePacerTests.swift
+++ b/Tests/VPNBypassTests/WritePacerTests.swift
@@ -1,0 +1,60 @@
+// WritePacerTests.swift
+// Coverage for the routing-socket write pacer (RouteKernel.WritePacer).
+//
+// Why this matters: every RTM write is broadcast to every open routing socket, and the kernel
+// silently drops messages for a socket whose receive buffer is full. An uninterrupted batch of
+// several hundred writes was observed swallowing the reply of GlobalProtect's concurrent
+// gateway-route read — which it misreads as "my gateway route was removed" and tears the
+// tunnel down. The pacer's contract: pause exactly at chunk boundaries within a burst, never
+// for sparse interactive writes, and start a fresh chunk after an idle gap.
+
+import XCTest
+@testable import VPNBypassCore
+
+final class WritePacerTests: XCTestCase {
+
+    private let second: UInt64 = 1_000_000_000
+
+    /// Within one dense burst, the pause must fire exactly every `chunkSize` writes —
+    /// bounding any listener's backlog to one chunk.
+    func testPausesExactlyAtChunkBoundaries() {
+        var pacer = RouteKernel.WritePacer(chunkSize: 4)
+        var pauses: [Int] = []
+        for i in 1...12 {
+            if pacer.recordWrite(nowNS: UInt64(i) * 1_000) { pauses.append(i) }
+        }
+        XCTAssertEqual(pauses, [4, 8, 12])
+    }
+
+    /// Sparse interactive operations (single route add from the UI) must never pause.
+    func testSparseWritesNeverPause() {
+        var pacer = RouteKernel.WritePacer(chunkSize: 4)
+        for i in 1...10 {
+            // Each write more than the idle-reset gap after the previous one.
+            XCTAssertFalse(pacer.recordWrite(nowNS: UInt64(i) * 2 * second))
+        }
+    }
+
+    /// An idle gap longer than the reset window starts a fresh chunk count: a new batch is a
+    /// new burst, not a continuation of the last one.
+    func testIdleGapResetsBurst() {
+        var pacer = RouteKernel.WritePacer(chunkSize: 4)
+        XCTAssertFalse(pacer.recordWrite(nowNS: 1_000))
+        XCTAssertFalse(pacer.recordWrite(nowNS: 2_000))
+        XCTAssertFalse(pacer.recordWrite(nowNS: 3_000))
+        // Gap > 1s: the count restarts, so the next write is #1, not the pausing #4.
+        let afterGap = 3_000 + 2 * second
+        XCTAssertFalse(pacer.recordWrite(nowNS: afterGap))
+        XCTAssertFalse(pacer.recordWrite(nowNS: afterGap + 1_000))
+        XCTAssertFalse(pacer.recordWrite(nowNS: afterGap + 2_000))
+        XCTAssertTrue(pacer.recordWrite(nowNS: afterGap + 3_000))
+    }
+
+    /// Defaults: a chunk stays well under one 8KB routing-socket receive buffer
+    /// (~50 messages), and the pause is long enough to be a real drain window.
+    func testDefaultsAreBufferSafe() {
+        let pacer = RouteKernel.WritePacer()
+        XCTAssertLessThanOrEqual(pacer.chunkSize, 40)
+        XCTAssertGreaterThanOrEqual(pacer.pauseMicroseconds, 100_000)
+    }
+}


### PR DESCRIPTION
## The problem (#65 resurfacing through a different mechanism)

v4's socket engine removed the fork storm, but GlobalProtect still flapped — worst right after screen unlock, for a minute or more. Fresh evidence from today's logs (8/8 drops share one signature):

```
13:44:12 pan_get_gateway: timeout.
13:44:14 pan_get_gateway: finalString no data.
13:44:14 Error: Failed to find route for <gateway>
13:44:14 Set retry network check event due to removed gateway route
```

GP forks a gateway-route READ and misreads an empty result as "my gateway route was removed". The reply goes missing because **every RTM write is broadcast to every open routing socket, and the kernel silently drops messages for a socket whose receive buffer (8KB ≈ ~50 messages) is full**. Our reconnect apply pushed ~370 adds + ~145 orphan deletes in ~1s — enough to swallow the reply of any concurrent `route -n get`.

Timing made it a loop: the apply fired **1 second after each tunnel restore**, exactly the window where GP re-checks its gateway most aggressively. One external drop (unlock-time network churn) became three drops in three minutes, each a few seconds after our batch landed. Two of today's drops were not preceded by any VPN Bypass activity — external churn hits the same fragile reader — but ours were the largest bursts and the only ones we control.

## The fix

- **Helper — paced writes** (`RouteKernel.WritePacer`): 200ms pause every 32 writes at the `routeSocketPerform` choke point, covering every mutation path (batch adds, removals, sweeps). Any listener's backlog stays well under one buffer, so a concurrent request/reply exchange can no longer lose its reply. Single interactive ops never pause. `helperVersion` 2.0.0 → 2.1.0.
- **App — reconnect settle gate**: the auto-apply after a VPN (re)connect waits for the tunnel to hold (20s warm / 10s cold; a drop during the wait cancels + re-arms; after 5 deferrals the delay collapses to 5s so it can't starve). Bypass routes are kept across drops, so waiting costs nothing functionally.
- **App — orphan grace on auto applies**: routes that merely rotated out of DNS (100–150 per cycle observed) are no longer deleted-and-readded every cycle; deletion waits 30 min (bounded at 400, oldest evicted first). User-initiated applies still delete immediately, so removing a domain keeps taking effect at once.
- **App — single-flight `checkVPNStatus`**: overlapping runs each committed the same transition (three "VPN disconnected" teardowns + three notifications for one drop, observed live). Now one run at a time with one queued trailing re-check.
- **App — hosts-file XPC deadline 10s → 30s**: it queues on the helper's serial queue behind now-paced batches and was observed timing out at 10s.

## Verification

- 977 tests, 0 failures (14 new: WritePacer ×4, ReconnectSettle ×4, OrphanGrace ×6)
- Helper compiles via `make build-helper` with the pacer wired in
- Live verification after release: observe GP across screen unlocks + reconnects with v4.6.2 installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN reconnect handling to preserve routes during brief connection drops.
  * Reduced duplicate status transitions and unnecessary route teardown.
  * Prevented routing issues during burst updates by pacing route writes.
  * Extended the host-file update timeout for slower operations.
  * Temporarily retains recently disconnected bypass routes and removes expired entries automatically.

* **Maintenance**
  * Updated the helper to version 2.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->