### PR TITLE
fix: stop any local process spending your proxy credentials (GHSA-gm4h-95p9-9w7v)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,13 @@ let package = Package(
     dependencies: [],
     targets: [
         .target(
+            name: "VPNBypassPeerAuth",
+            path: "Sources/VPNBypassPeerAuth",
+            publicHeadersPath: "include"
+        ),
+        .target(
             name: "VPNBypassCore",
-            dependencies: [],
+            dependencies: ["VPNBypassPeerAuth"],
             path: "Sources/VPNBypassCore",
             resources: [
                 .process("Resources")

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ A **route** is a place traffic can exit:
 
 A **rule** maps traffic to a route by `domain`, `suffix`, `ip`, `cidr`, `service`, or `process`. The first matching rule wins; anything unmatched takes the **default** route. Direct and detected VPN routes appear automatically; proxy and Tailscale-peer routes are ones you add.
 
+A proxy route's `127.0.0.1` listener holds your upstream proxy credentials, so it will not serve a client that cannot prove it is you. Any process on the machine can reach a loopback port, and macOS gives a TCP listener no way to see who connected, so the listener asks for a password instead. Use the **Copy exports** button on the route — it hands you the address with the credentials already in it:
+
+```bash
+export HTTPS_PROXY="http://vpnb:<secret>@127.0.0.1:18042"
+```
+
+The secret is generated once and kept in the app's config file, which only your account can read. Copy the exports again if you ever reset your config.
+
 ## Installation
 
 ### Homebrew (Recommended)
@@ -268,6 +276,10 @@ The app will prompt for admin password when modifying `/etc/hosts`. If you deny,
 Some VPNs force DNS through the tunnel. The hosts file entries help bypass this, but you may also need to:
 - Disable "Route all DNS through VPN" in your VPN client
 - Use a local DNS resolver
+
+### Proxy route returns `407 Proxy Authentication Required`
+
+Your `HTTP(S)_PROXY` is pointing at the listener without its credentials — usually an address copied before you upgraded. Open the route and use **Copy exports** again, then re-source it wherever you keep it. The plain `http://127.0.0.1:<port>` form no longer works, by design: without it, any other account on the machine could spend your upstream proxy credentials.
 
 ### Route verification failing
 

--- a/Sources/VPNBypassCore/ConfigModel.swift
+++ b/Sources/VPNBypassCore/ConfigModel.swift
@@ -96,6 +96,12 @@ struct Config: Codable {
     var defaultRouteId: UUID? = nil
     var schemaVersion: Int = 1
     var multiRouteEnabled: Bool = false  // Opt-in experimental: show Routes tab and start proxy listeners
+    /// Shared secret a local client must present to a route's 127.0.0.1 listener before the
+    /// forwarder will spend this machine's upstream proxy credentials (GHSA-gm4h-95p9-9w7v).
+    /// It lives here because the config file is 0600 — the owner can read it, another local
+    /// account cannot, and a TCP listener has no peer uid to check instead. Optional so a
+    /// config written before 4.6.3 still decodes; RouteManager mints one on first use.
+    var localProxySecret: String? = nil
     /// Tunnels seen previously, so a VPN that is not connected right now can still be chosen
     /// for a route or a pin. Live enumeration only reports tunnels that are UP.
     var rememberedVPNLinks: [RouteManager.RememberedLink] = []
@@ -467,6 +473,14 @@ struct Config: Codable {
             ], ipRanges: [])
         ]
     }
+
+    /// A fresh 256-bit local-hop secret as lowercase hex. Hex, not base64: the secret is
+    /// interpolated into a proxy URL's userinfo (`http://vpnb:<secret>@127.0.0.1:port`) and
+    /// base64's `/` is not legal there, so it would need escaping at every call site.
+    static func makeLocalProxySecret() -> String {
+        (0..<32).map { _ in String(format: "%02x", UInt8.random(in: .min ... .max)) }.joined()
+    }
+
 }
 
 struct DomainEntry: Codable, Identifiable, Equatable {

--- a/Sources/VPNBypassCore/ConfigModel.swift
+++ b/Sources/VPNBypassCore/ConfigModel.swift
@@ -133,6 +133,10 @@ struct Config: Codable {
         defaultRouteId = try container.decodeIfPresent(UUID.self, forKey: .defaultRouteId)
         schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 1
         multiRouteEnabled = try container.decodeIfPresent(Bool.self, forKey: .multiRouteEnabled) ?? false
+        // Must be decoded explicitly: this initialiser is hand-written, so a property left
+        // out here is encoded to disk and then silently read back as nil. For this one that
+        // would mint a fresh secret on every launch and 407 every previously copied export.
+        localProxySecret = try container.decodeIfPresent(String.self, forKey: .localProxySecret)
         rememberedVPNLinks = try container.decodeIfPresent([RouteManager.RememberedLink].self, forKey: .rememberedVPNLinks) ?? []
         pinnedVPNInterface = try container.decodeIfPresent(String.self, forKey: .pinnedVPNInterface)
         pinnedVPNProductHint = try container.decodeIfPresent(String.self, forKey: .pinnedVPNProductHint)
@@ -300,6 +304,7 @@ struct Config: Codable {
     /// in-app config keeps the live values; Import re-prompts for secrets.
     func sanitizedForExport() -> Config {
         var copy = self
+        copy.localProxySecret = nil        // a valid local proxy password — never share it
         copy.proxyConfig.username = ""
         copy.proxyConfig.password = ""
         copy.routes = copy.routes.map { route in

--- a/Sources/VPNBypassCore/HookGenerator.swift
+++ b/Sources/VPNBypassCore/HookGenerator.swift
@@ -12,8 +12,12 @@ enum HookGenerator {
     /// Shell export block pointing HTTP(S)_PROXY at a route's local listener.
     /// Sourcing it routes that shell's HTTP(S) traffic through the route; the
     /// no_proxy entries keep loopback (incl. the listener itself) direct.
-    static func shellExports(port: UInt16) -> String {
-        let url = "http://127.0.0.1:\(port)"
+    /// `secret` is the local-hop credential the listener now demands (GHSA-gm4h-95p9-9w7v);
+    /// it rides in the URL's userinfo, which every HTTP(S)_PROXY consumer understands. It is
+    /// deliberately NOT optional — an exports block without it is a block that cannot talk to
+    /// the listener, and that must be a compile error rather than a silent runtime 407.
+    static func shellExports(port: UInt16, secret: String) -> String {
+        let url = "http://vpnb:\(secret)@127.0.0.1:\(port)"
         return """
         export HTTP_PROXY="\(url)"
         export HTTPS_PROXY="\(url)"

--- a/Sources/VPNBypassCore/LoopbackPeerAuth.swift
+++ b/Sources/VPNBypassCore/LoopbackPeerAuth.swift
@@ -1,0 +1,44 @@
+// LoopbackPeerAuth.swift
+// Same-uid gate for the 127.0.0.1 proxy listener.
+//
+// The control socket uses getpeereid() on AF_UNIX. The proxy is Network.framework
+// TCP, so there is no peer credential on the socket. We map the client's
+// ephemeral source port to a uid via libproc and require it to match getuid().
+// Unknown / conflicting lookups fail closed (same as a getpeereid() error).
+
+import Darwin
+import Network
+import VPNBypassPeerAuth
+
+enum LoopbackPeerAuth {
+    /// Policy used by the accept path. `nil` means "could not identify the peer".
+    static func allows(peerUID: uid_t?) -> Bool {
+        guard let peerUID else { return false }
+        return peerUID == getuid()
+    }
+
+    /// Identify the TCP client on `connection` and apply `allows(peerUID:)`.
+    /// Call only after the connection is `.ready` so `currentPath` is populated.
+    static func allows(connection: NWConnection) -> Bool {
+        allows(peerUID: uid(of: connection))
+    }
+
+    static func uid(of connection: NWConnection) -> uid_t? {
+        guard let port = remoteTCPPort(of: connection) else { return nil }
+        return uidOwningLocalTCPPort(port)
+    }
+
+    static func remoteTCPPort(of connection: NWConnection) -> UInt16? {
+        guard let endpoint = connection.currentPath?.remoteEndpoint else { return nil }
+        if case .hostPort(_, let port) = endpoint {
+            return port.rawValue
+        }
+        return nil
+    }
+
+    static func uidOwningLocalTCPPort(_ port: UInt16) -> uid_t? {
+        var uid: uid_t = 0
+        guard loopback_peer_uid_for_tcp_port(port, &uid) == 0 else { return nil }
+        return uid
+    }
+}

--- a/Sources/VPNBypassCore/ProxyForwarder.swift
+++ b/Sources/VPNBypassCore/ProxyForwarder.swift
@@ -38,6 +38,18 @@ final class ProxyForwarder {
 
     let listenPort: UInt16
 
+    // Shared secret a LOCAL client must present as `Proxy-Authorization: Basic` before we
+    // will spend the owner's UPSTREAM credentials on its behalf (GHSA-gm4h-95p9-9w7v).
+    //
+    // The listener is plain TCP on 127.0.0.1, and macOS has no way to read the peer's uid
+    // on a TCP socket: getpeereid(3) requires a UNIX-domain socket (that is why the control
+    // socket can check uid and this cannot), and the sysctl route needs kernel struct
+    // layouts Apple does not publish. So the caller proves it is the owner by presenting a
+    // secret only the owner can read — it lives in the 0600 config and is handed to apps
+    // through the generated exports. nil means no secret is configured and the listener is
+    // open, which is the pre-4.6.3 behaviour and what the unit tests drive.
+    private let localSecret: String?
+
     // The upstream a NEW tunnel chains through. Mutable so a route can be re-pointed
     // live (e.g. switch a residential proxy's port to change the exit IP) WITHOUT tearing down the
     // listener — the local port (and any app's HTTPS_PROXY) stays put; only connections
@@ -65,9 +77,10 @@ final class ProxyForwarder {
 
     private static let startTimeout: TimeInterval = 5.0
 
-    init(listenPort: UInt16, upstream: Upstream) {
+    init(listenPort: UInt16, upstream: Upstream, localSecret: String? = nil) {
         self.listenPort = listenPort
         self.upstream = upstream
+        self.localSecret = localSecret
     }
 
     /// Actual bound port — equals `listenPort` unless that was 0, in which case it is
@@ -181,6 +194,7 @@ final class ProxyForwarder {
         let tunnel = Tunnel(client: connection,
                             upstream: upstream,
                             boundInterface: resolvedInterface,
+                            localSecret: localSecret,
                             queue: queue)
         activeTunnels.append(tunnel)
         tunnel.onDone = { [weak self, weak tunnel] in
@@ -242,6 +256,7 @@ private final class Tunnel {
     private let client: NWConnection
     private let upstream: ProxyForwarder.Upstream
     private let boundInterface: NWInterface?
+    private let localSecret: String?
     private let queue: DispatchQueue
 
     private var server: NWConnection?
@@ -266,10 +281,12 @@ private final class Tunnel {
     init(client: NWConnection,
          upstream: ProxyForwarder.Upstream,
          boundInterface: NWInterface?,
+         localSecret: String?,
          queue: DispatchQueue) {
         self.client = client
         self.upstream = upstream
         self.boundInterface = boundInterface
+        self.localSecret = localSecret
         self.queue = queue
     }
 
@@ -320,6 +337,12 @@ private final class Tunnel {
         let requestLine = headString.components(separatedBy: "\r\n").first ?? ""
         let tokens = requestLine.split(separator: " ", maxSplits: 2, omittingEmptySubsequences: true).map(String.init)
         guard tokens.count >= 2 else { sendClient400(); return }
+
+        // Authenticate the LOCAL caller before anything else. Until this passes we have no
+        // reason to believe the client is the owner, so we neither dial out nor attach the
+        // owner's upstream credentials. Checked ahead of authority parsing so an
+        // unauthenticated caller cannot use our 400-vs-407 replies to probe the parser.
+        guard isLocalCallerAuthorized(head: headString) else { sendClient407(); return }
 
         let method = tokens[0].uppercased()
         let target = tokens[1]
@@ -590,13 +613,68 @@ private final class Tunnel {
         server.start(queue: queue)
     }
 
+    /// Rewrite the client's head for the upstream: drop any `Proxy-Authorization` the client
+    /// sent (it is the LOCAL hop's credential — ours, or a wrong guess — and must never be
+    /// forwarded or duplicated onto the upstream), then insert the upstream's own.
     private func injectProxyAuth(into head: Data) -> Data {
-        guard !upstream.username.isEmpty, let lineEnd = head.range(of: Self.crlf) else { return head }
+        let stripped = Self.removingProxyAuthorization(from: head)
+        guard !upstream.username.isEmpty, let lineEnd = stripped.range(of: Self.crlf) else { return stripped }
         var out = Data()
-        out.append(head.subdata(in: head.startIndex..<lineEnd.upperBound))               // request line + CRLF
+        out.append(stripped.subdata(in: stripped.startIndex..<lineEnd.upperBound))        // request line + CRLF
         out.append(Data("Proxy-Authorization: Basic \(basicAuthToken())\r\n".utf8))
-        out.append(head.subdata(in: lineEnd.upperBound..<head.endIndex))                  // remaining headers
+        out.append(stripped.subdata(in: lineEnd.upperBound..<stripped.endIndex))          // remaining headers
         return out
+    }
+
+    /// Remove every `Proxy-Authorization` header line from a request head, preserving the
+    /// request line and every other header byte-for-byte.
+    static func removingProxyAuthorization(from head: Data) -> Data {
+        guard let text = String(data: head, encoding: .utf8) else { return head }
+        let lines = text.components(separatedBy: "\r\n")
+        let kept = lines.enumerated().filter { index, line in
+            index == 0 || !line.lowercased().hasPrefix("proxy-authorization:")
+        }.map { $0.element }
+        return Data(kept.joined(separator: "\r\n").utf8)
+    }
+
+    // MARK: Local-caller authentication
+
+    /// True when no secret is configured (open listener, pre-4.6.3 behaviour) or the client
+    /// presented exactly it. The token is compared in constant time so a local attacker
+    /// cannot recover it byte-by-byte from response timing.
+    private func isLocalCallerAuthorized(head: String) -> Bool {
+        guard let secret = localSecret else { return true }
+        guard let presented = Self.basicProxyAuthorization(in: head) else { return false }
+        return Self.constantTimeEquals(presented, Self.expectedToken(for: secret))
+    }
+
+    /// The base64 blob from the first `Proxy-Authorization: Basic <token>` header, if any.
+    /// Header names are case-insensitive and the value may carry surrounding whitespace.
+    static func basicProxyAuthorization(in head: String) -> String? {
+        for line in head.components(separatedBy: "\r\n").dropFirst() {
+            guard line.lowercased().hasPrefix("proxy-authorization:") else { continue }
+            let value = line.drop { $0 != ":" }.dropFirst().trimmingCharacters(in: .whitespaces)
+            let parts = value.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
+            guard parts.count == 2, parts[0].lowercased() == "basic" else { return nil }
+            return String(parts[1]).trimmingCharacters(in: .whitespaces)
+        }
+        return nil
+    }
+
+    /// The base64 of `vpnb:<secret>` — what the generated exports make a client send.
+    static func expectedToken(for secret: String) -> String {
+        Data("vpnb:\(secret)".utf8).base64EncodedString()
+    }
+
+    /// Length-revealing but content-independent comparison: every byte of the longer input
+    /// is folded in, so the loop count depends only on lengths, never on where a mismatch is.
+    static func constantTimeEquals(_ a: String, _ b: String) -> Bool {
+        let x = Array(a.utf8), y = Array(b.utf8)
+        var diff = UInt8(x.count == y.count ? 0 : 1)
+        for i in 0..<max(x.count, y.count) {
+            diff |= (i < x.count ? x[i] : 0) ^ (i < y.count ? y[i] : 0)
+        }
+        return diff == 0
     }
 
     // MARK: Bidirectional relay
@@ -704,6 +782,14 @@ private final class Tunnel {
             if error != nil { self.cancel(); return }
             then?()
         })
+    }
+
+    /// Refuse an unauthenticated local caller. `Proxy-Authenticate` is included so a client
+    /// that can prompt (a browser pointed here by a PAC) has something to prompt against.
+    private func sendClient407() {
+        let response = "HTTP/1.1 407 Proxy Authentication Required\r\n"
+            + "Proxy-Authenticate: Basic realm=\"VPN Bypass\"\r\n\r\n"
+        send(Data(response.utf8), on: client) { [weak self] in self?.cancel() }
     }
 
     private func sendClient400() {

--- a/Sources/VPNBypassCore/ProxyForwarder.swift
+++ b/Sources/VPNBypassCore/ProxyForwarder.swift
@@ -41,13 +41,15 @@ final class ProxyForwarder {
     // Shared secret a LOCAL client must present as `Proxy-Authorization: Basic` before we
     // will spend the owner's UPSTREAM credentials on its behalf (GHSA-gm4h-95p9-9w7v).
     //
-    // The listener is plain TCP on 127.0.0.1, and macOS has no way to read the peer's uid
-    // on a TCP socket: getpeereid(3) requires a UNIX-domain socket (that is why the control
-    // socket can check uid and this cannot), and the sysctl route needs kernel struct
-    // layouts Apple does not publish. So the caller proves it is the owner by presenting a
-    // secret only the owner can read — it lives in the 0600 config and is handed to apps
-    // through the generated exports. nil means no secret is configured and the listener is
-    // open, which is the pre-4.6.3 behaviour and what the unit tests drive.
+    // The listener is plain TCP on 127.0.0.1: getpeereid(3) needs a UNIX-domain socket
+    // (the control socket uses that), and net.inet.tcp.pcblist64 needs unpublished
+    // kernel layouts. The caller still proves ownership with this secret (0600 config,
+    // handed out in generated exports). nil means no secret, which is the pre-4.6.3
+    // behaviour and what the unit tests drive.
+    //
+    // A second layer (LoopbackPeerAuth) drops the socket before we read a byte when
+    // libproc cannot name the source port's owner as getuid(). That uses the published
+    // PROC_PIDFDSOCKETINFO API, not pcblist. Lookup failure is a reject.
     private let localSecret: String?
 
     // The upstream a NEW tunnel chains through. Mutable so a route can be re-pointed
@@ -190,7 +192,30 @@ final class ProxyForwarder {
     // MARK: - Connection acceptance
 
     private func accept(_ connection: NWConnection) {
-        // Runs on `queue` (the listener's queue), so touching activeTunnels is safe.
+        // Runs on `queue`. Identify the peer before reading a byte (same policy
+        // as ControlSocketServer's getpeereid check). NWConnection is TCP, so
+        // wait until `.ready` then map the source port to a uid via libproc.
+        // The localSecret check still runs later on the first request.
+        connection.stateUpdateHandler = { [weak self] state in
+            guard let self = self else { return }
+            switch state {
+            case .ready:
+                guard LoopbackPeerAuth.allows(connection: connection) else {
+                    NSLog("VPN Bypass: rejected loopback proxy client (peer uid mismatch or unknown)")
+                    connection.cancel()
+                    return
+                }
+                self.startAuthorizedTunnel(connection)
+            case .failed, .cancelled:
+                break
+            default:
+                break
+            }
+        }
+        connection.start(queue: queue)
+    }
+
+    private func startAuthorizedTunnel(_ connection: NWConnection) {
         let tunnel = Tunnel(client: connection,
                             upstream: upstream,
                             boundInterface: resolvedInterface,

--- a/Sources/VPNBypassCore/ProxyForwarder.swift
+++ b/Sources/VPNBypassCore/ProxyForwarder.swift
@@ -645,6 +645,9 @@ private final class Tunnel {
     }
 
     private func isValidAuthority(_ authority: String) -> Bool {
+        if authority.contains(where: { $0 == "\r" || $0 == "\n" || $0 == "\0" }) {
+            return false
+        }
         guard let colon = authority.lastIndex(of: ":") else { return false }
         let host = authority[..<colon]
         let portText = authority[authority.index(after: colon)...]

--- a/Sources/VPNBypassCore/ProxyForwarder.swift
+++ b/Sources/VPNBypassCore/ProxyForwarder.swift
@@ -644,8 +644,28 @@ private final class Tunnel {
         Data("\(upstream.username):\(upstream.password)".utf8).base64EncodedString()
     }
 
+    /// Gate on the CONNECT authority BEFORE it is interpolated into the request line and
+    /// the `Host:` header that connectRequest() sends upstream — a hop that also carries
+    /// the owner's `Proxy-Authorization: Basic`. A local client that gets a line break in
+    /// here appends headers, or a whole second request, to that authenticated connection
+    /// (GHSA-gm4h-95p9-9w7v).
+    ///
+    /// Two details make the obvious check wrong, so they are spelled out:
+    ///
+    /// 1. Iterate `unicodeScalars`, NOT `Characters`. Swift treats CR LF as ONE extended
+    ///    grapheme cluster that compares equal to neither "\r" nor "\n", so a
+    ///    `contains(where: { $0 == "\r" || $0 == "\n" })` over Characters silently passes
+    ///    an embedded CRLF pair. processClientHead cuts the request line at the first CRLF
+    ///    today, so nothing on the wire reaches here with a pair — but this guard must hold
+    ///    on its own, not on that.
+    /// 2. Reject the whole C0 range, DEL and SP rather than just CR/LF/NUL. A bare LF (and,
+    ///    on lenient proxies, a bare CR) is the reachable injection; TAB and DEL are not
+    ///    line breaks but are still illegal in a request-target and in a header value, and
+    ///    a CR/LF-only blocklist lets them through to the upstream verbatim. Every scalar
+    ///    below 0x21 encodes to a single byte in UTF-8, so a scalar check here is exactly a
+    ///    byte check on the wire.
     private func isValidAuthority(_ authority: String) -> Bool {
-        if authority.contains(where: { $0 == "\r" || $0 == "\n" || $0 == "\0" }) {
+        if authority.unicodeScalars.contains(where: { $0.value <= 0x20 || $0.value == 0x7F }) {
             return false
         }
         guard let colon = authority.lastIndex(of: ":") else { return false }

--- a/Sources/VPNBypassCore/ProxyForwarder.swift
+++ b/Sources/VPNBypassCore/ProxyForwarder.swift
@@ -658,14 +658,28 @@ private final class Tunnel {
     ///    an embedded CRLF pair. processClientHead cuts the request line at the first CRLF
     ///    today, so nothing on the wire reaches here with a pair — but this guard must hold
     ///    on its own, not on that.
-    /// 2. Reject the whole C0 range, DEL and SP rather than just CR/LF/NUL. A bare LF (and,
-    ///    on lenient proxies, a bare CR) is the reachable injection; TAB and DEL are not
-    ///    line breaks but are still illegal in a request-target and in a header value, and
-    ///    a CR/LF-only blocklist lets them through to the upstream verbatim. Every scalar
-    ///    below 0x21 encodes to a single byte in UTF-8, so a scalar check here is exactly a
+    /// 2. Reject more than CR/LF/NUL, because "what counts as a line break" depends on how
+    ///    the upstream parses. A byte-oriented parser breaks only on 0x0A/0x0D, so the C0
+    ///    range covers the real wire attack — a bare LF, or a bare CR on lenient proxies.
+    ///    But a parser that decodes the request to TEXT first also breaks on NEL and on
+    ///    LINE/PARAGRAPH SEPARATOR: Python's `str.splitlines()` splits on U+0085, U+2028 and
+    ///    U+2029 while `bytes.splitlines()` does not. We cannot know which kind of proxy is
+    ///    upstream, so all three are refused too. TAB and DEL are not breaks under either,
+    ///    but are illegal in a request-target and in a header value, so they go as well.
+    ///
+    ///    Other non-ASCII is deliberately still ALLOWED: a raw IDN host is not a break to
+    ///    any parser, and refusing it would be a behaviour change unrelated to this bug.
+    ///
+    ///    Every scalar at or below 0x20 encodes to a single byte in UTF-8 and no multi-byte
+    ///    sequence contains a byte below 0x80, so for that range a scalar check is exactly a
     ///    byte check on the wire.
     private func isValidAuthority(_ authority: String) -> Bool {
-        if authority.unicodeScalars.contains(where: { $0.value <= 0x20 || $0.value == 0x7F }) {
+        let forbidden: (Unicode.Scalar) -> Bool = {
+            $0.value <= 0x20 || $0.value == 0x7F        // C0 controls, SP, DEL
+                || (0x80...0x9F).contains($0.value)     // C1 controls, U+0085 NEL among them
+                || $0.value == 0x2028 || $0.value == 0x2029   // LINE / PARAGRAPH SEPARATOR
+        }
+        if authority.unicodeScalars.contains(where: forbidden) {
             return false
         }
         guard let colon = authority.lastIndex(of: ":") else { return false }

--- a/Sources/VPNBypassCore/ProxyListenerManager.swift
+++ b/Sources/VPNBypassCore/ProxyListenerManager.swift
@@ -59,7 +59,7 @@ final class ProxyListenerManager: ObservableObject {
         var toRepoint: [(id: UUID, route: Route)] = []
         for (id, _) in forwarders {
             if let route = byId[id] {
-                if fingerprints[id] != Self.upstreamFingerprint(route, boundInterface: boundInterface) {
+                if fingerprints[id] != Self.upstreamFingerprint(route, boundInterface: boundInterface, localSecret: localSecret) {
                     toRepoint.append((id, route))
                 }
             } else {
@@ -75,7 +75,7 @@ final class ProxyListenerManager: ObservableObject {
         for (id, route) in toRepoint {
             if let upstream = Self.makeUpstream(route: route, boundInterface: boundInterface) {
                 forwarders[id]?.updateUpstream(upstream)   // listener + ports[id] stay put
-                fingerprints[id] = Self.upstreamFingerprint(route, boundInterface: boundInterface)
+                fingerprints[id] = Self.upstreamFingerprint(route, boundInterface: boundInterface, localSecret: localSecret)
             } else {
                 forwarders[id]?.stop(); forwarders[id] = nil; ports[id] = nil; fingerprints[id] = nil
             }
@@ -95,7 +95,7 @@ final class ProxyListenerManager: ObservableObject {
                 guard let upstream = Self.makeUpstream(route: route, boundInterface: boundInterface) else { continue }
                 if let result = Self.startForwarder(route: route, upstream: upstream, localSecret: localSecret) {
                     started.append((route.id, result.forwarder, result.port,
-                                    Self.upstreamFingerprint(route, boundInterface: boundInterface)))
+                                    Self.upstreamFingerprint(route, boundInterface: boundInterface, localSecret: localSecret)))
                 }
             }
             Task { @MainActor [weak self] in
@@ -206,8 +206,14 @@ final class ProxyListenerManager: ObservableObject {
     /// excluded so a plain reconcile doesn't re-mint the session every pass; a future
     /// `rotate` verb restarts explicitly. Used only for in-process equality comparison, so
     /// Hasher's per-process seed is fine and no plaintext credential is retained.
-    nonisolated static func upstreamFingerprint(_ route: Route, boundInterface: String?) -> Int {
+    /// `localSecret` is part of the listener's identity, not just its upstream: a running
+    /// ProxyForwarder captured it at init and cannot be re-pointed at a new one, so a rotated
+    /// secret has to restart the listener or the old credential keeps working and every newly
+    /// copied export gets a 407.
+    nonisolated static func upstreamFingerprint(_ route: Route, boundInterface: String?,
+                                                localSecret: String? = nil) -> Int {
         var h = Hasher()
+        h.combine(localSecret ?? "")
         h.combine(route.egress)
         h.combine(route.proxyHost ?? "")
         h.combine(route.proxyPort ?? -1)

--- a/Sources/VPNBypassCore/ProxyListenerManager.swift
+++ b/Sources/VPNBypassCore/ProxyListenerManager.swift
@@ -40,7 +40,11 @@ final class ProxyListenerManager: ObservableObject {
     /// `boundInterface` is the physical interface (e.g. "en0") that upstream
     /// sockets bind to so the proxy hop escapes a full-tunnel VPN (nil = OS default).
     /// `completion` runs on the main actor once starts settle.
-    func reconcile(routes: [Route], boundInterface: String?, completion: (() -> Void)? = nil) {
+    /// `localSecret` is the shared secret each new listener will demand from its local
+    /// clients. Defaults to nil (open listener) so the unit tests, which drive reconcile
+    /// directly, keep exercising the transport without an auth step.
+    func reconcile(routes: [Route], boundInterface: String?, localSecret: String? = nil,
+                   completion: (() -> Void)? = nil) {
         let proxyRoutes = routes.filter {
             $0.enabled && Self.usesLocalListener($0.egress) && !($0.proxyHost ?? "").isEmpty
         }
@@ -89,7 +93,7 @@ final class ProxyListenerManager: ObservableObject {
             var started: [(id: UUID, forwarder: ProxyForwarder, port: UInt16, fingerprint: Int)] = []
             for route in toStart {
                 guard let upstream = Self.makeUpstream(route: route, boundInterface: boundInterface) else { continue }
-                if let result = Self.startForwarder(route: route, upstream: upstream) {
+                if let result = Self.startForwarder(route: route, upstream: upstream, localSecret: localSecret) {
                     started.append((route.id, result.forwarder, result.port,
                                     Self.upstreamFingerprint(route, boundInterface: boundInterface)))
                 }
@@ -122,11 +126,12 @@ final class ProxyListenerManager: ObservableObject {
     /// Start a single proxy forwarder and return it with its bound port.
     /// Returns nil if start() fails or no ephemeral port is assigned.
     /// Called from the startQueue background thread — must be nonisolated.
-    nonisolated static func startForwarder(route: Route, upstream: ProxyForwarder.Upstream) -> (forwarder: ProxyForwarder, port: UInt16)? {
+    nonisolated static func startForwarder(route: Route, upstream: ProxyForwarder.Upstream,
+                                           localSecret: String? = nil) -> (forwarder: ProxyForwarder, port: UInt16)? {
         // Try the route's STABLE preferred port first (so an app's HTTPS_PROXY
         // config survives restarts), then fall back to an OS-assigned port.
         for candidate in [preferredPort(for: route), 0] {
-            let forwarder = ProxyForwarder(listenPort: candidate, upstream: upstream)
+            let forwarder = ProxyForwarder(listenPort: candidate, upstream: upstream, localSecret: localSecret)
             if (try? forwarder.start()) != nil, let port = forwarder.boundPort {
                 return (forwarder, port)
             }

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -227,6 +227,17 @@ final class RouteManager: ObservableObject {
         }
     }
     
+    /// The local-hop secret every proxy listener demands, minted and persisted on first
+    /// use so the listener and the generated exports agree on it across restarts.
+    @discardableResult
+    func ensureLocalProxySecret() -> String {
+        if let existing = config.localProxySecret, !existing.isEmpty { return existing }
+        let minted = Config.makeLocalProxySecret()
+        config.localProxySecret = minted
+        saveConfig()
+        return minted
+    }
+
     func saveConfig() {
         // Daily backup - overwrite if older than 24 hours
         createDailyBackupIfNeeded()
@@ -4100,7 +4111,9 @@ final class RouteManager: ObservableObject {
             return
         }
         let iface = await detectPhysicalInterface()
-        ProxyListenerManager.shared.reconcile(routes: listenerRoutesRespectingGPShadow(), boundInterface: iface)
+        ProxyListenerManager.shared.reconcile(routes: listenerRoutesRespectingGPShadow(),
+                                             boundInterface: iface,
+                                             localSecret: ensureLocalProxySecret())
     }
 
     /// `config.routes` with any Tailscale-peer route whose IP is inside GlobalProtect's

--- a/Sources/VPNBypassCore/RoutesTab.swift
+++ b/Sources/VPNBypassCore/RoutesTab.swift
@@ -392,7 +392,10 @@ struct RouteRow: View {
             // Copy shell exports — only available once listener is up
             if let port = listenerPort {
                 Button {
-                    let text = HookGenerator.shellExports(port: port)
+                    // RouteRow has no routeManager in scope; the singleton is what
+                    // ProxyListenerManager.shared above already uses from this file.
+                    let text = HookGenerator.shellExports(port: port,
+                                                          secret: RouteManager.shared.ensureLocalProxySecret())
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(text, forType: .string)
                     withAnimation { didCopy = true }

--- a/Sources/VPNBypassPeerAuth/include/loopback_peer_auth.h
+++ b/Sources/VPNBypassPeerAuth/include/loopback_peer_auth.h
@@ -1,0 +1,23 @@
+#ifndef LOOPBACK_PEER_AUTH_H
+#define LOOPBACK_PEER_AUTH_H
+
+#include <sys/types.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Look up the uid that currently owns a local TCP bind of `host_order_port`
+// (the client's ephemeral source port on 127.0.0.1).
+//
+// Returns 0 and writes *out_uid when exactly one uid is found.
+// Returns -1 (fail closed) when the port is unused, the lookup fails, or
+// two different uids appear to own the same port.
+int loopback_peer_uid_for_tcp_port(uint16_t host_order_port, uid_t *out_uid);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Sources/VPNBypassPeerAuth/loopback_peer_auth.c
+++ b/Sources/VPNBypassPeerAuth/loopback_peer_auth.c
@@ -1,0 +1,104 @@
+#include "loopback_peer_auth.h"
+
+#include <arpa/inet.h>
+#include <libproc.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/proc_info.h>
+#include <unistd.h>
+
+int loopback_peer_uid_for_tcp_port(uint16_t host_order_port, uid_t *out_uid) {
+    if (out_uid == NULL || host_order_port == 0) {
+        return -1;
+    }
+
+    // insi_lport is stored in network byte order (same as inp_lport).
+    const int port_nbo = (int)htons(host_order_port);
+
+    int list_bytes = proc_listpids(PROC_ALL_PIDS, 0, NULL, 0);
+    if (list_bytes <= 0) {
+        return -1;
+    }
+    list_bytes += (int)sizeof(pid_t) * 64;
+    pid_t *pids = calloc((size_t)list_bytes / sizeof(pid_t) + 1, sizeof(pid_t));
+    if (pids == NULL) {
+        return -1;
+    }
+    int got_bytes = proc_listpids(PROC_ALL_PIDS, 0, pids, list_bytes);
+    if (got_bytes <= 0) {
+        free(pids);
+        return -1;
+    }
+    const int npids = got_bytes / (int)sizeof(pid_t);
+
+    int found = 0;
+    uid_t found_uid = 0;
+
+    for (int i = 0; i < npids; i++) {
+        const pid_t pid = pids[i];
+        if (pid <= 0) {
+            continue;
+        }
+
+        int fd_bytes = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, NULL, 0);
+        if (fd_bytes <= 0) {
+            continue;
+        }
+        struct proc_fdinfo *fds = malloc((size_t)fd_bytes);
+        if (fds == NULL) {
+            continue;
+        }
+        int fd_got = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, fds, fd_bytes);
+        if (fd_got <= 0) {
+            free(fds);
+            continue;
+        }
+        const int nfd = fd_got / (int)sizeof(struct proc_fdinfo);
+        for (int j = 0; j < nfd; j++) {
+            if (fds[j].proc_fdtype != PROX_FDTYPE_SOCKET) {
+                continue;
+            }
+            struct socket_fdinfo si;
+            memset(&si, 0, sizeof(si));
+            int si_got = proc_pidfdinfo(pid, fds[j].proc_fd, PROC_PIDFDSOCKETINFO,
+                                        &si, (int)sizeof(si));
+            if (si_got < (int)sizeof(struct socket_info)) {
+                continue;
+            }
+            if (si.psi.soi_protocol != IPPROTO_TCP) {
+                continue;
+            }
+            if (si.psi.soi_family != AF_INET && si.psi.soi_family != AF_INET6) {
+                continue;
+            }
+            // pri_in and pri_tcp.tcpsi_ini share the same leading in_sockinfo.
+            if (si.psi.soi_proto.pri_in.insi_lport != port_nbo) {
+                continue;
+            }
+
+            struct proc_bsdinfo bsd;
+            memset(&bsd, 0, sizeof(bsd));
+            if (proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &bsd, (int)sizeof(bsd)) <= 0) {
+                free(fds);
+                free(pids);
+                return -1;
+            }
+            if (!found) {
+                found = 1;
+                found_uid = bsd.pbi_uid;
+            } else if (found_uid != bsd.pbi_uid) {
+                free(fds);
+                free(pids);
+                return -1;
+            }
+        }
+        free(fds);
+    }
+    free(pids);
+
+    if (!found) {
+        return -1;
+    }
+    *out_uid = found_uid;
+    return 0;
+}

--- a/Tests/VPNBypassTests/ConfigCodableTests.swift
+++ b/Tests/VPNBypassTests/ConfigCodableTests.swift
@@ -11,6 +11,28 @@ import XCTest
 /// missing newer fields still decode correctly.
 final class ConfigBackwardCompatTests: XCTestCase {
 
+    /// Config hand-writes `init(from:)` while letting the encoder be synthesised, so a new
+    /// property is WRITTEN to disk and then silently read back as nil unless someone adds a
+    /// decode line for it. For localProxySecret that mints a fresh secret on every launch and
+    /// 407s every proxy address the user had already copied (GHSA-gm4h-95p9-9w7v).
+    func testLocalProxySecretSurvivesAnEncodeDecodeRoundTrip() throws {
+        var cfg = RouteManager.Config()
+        cfg.localProxySecret = "deadbeefcafe"
+        let decoded = try JSONDecoder().decode(RouteManager.Config.self,
+                                               from: try JSONEncoder().encode(cfg))
+        XCTAssertEqual(decoded.localProxySecret, "deadbeefcafe",
+                       "the secret must survive a save/load or every copied export breaks on restart")
+    }
+
+    /// A config written before the field existed must still decode, leaving it nil so
+    /// ensureLocalProxySecret() mints one.
+    func testConfigWithoutLocalProxySecretStillDecodes() throws {
+        let json = Data("{\"autoApplyOnVPN\":true}".utf8)
+        let decoded = try JSONDecoder().decode(RouteManager.Config.self, from: json)
+        XCTAssertNil(decoded.localProxySecret)
+    }
+
+
     // MARK: - Empty JSON → all defaults
 
     func testDecodeEmptyJSONProducesAllDefaults() throws {

--- a/Tests/VPNBypassTests/ExportSanitizationTests.swift
+++ b/Tests/VPNBypassTests/ExportSanitizationTests.swift
@@ -8,6 +8,19 @@ import XCTest
 
 final class ExportSanitizationTests: XCTestCase {
 
+    /// The local-hop secret is a working password for this machine's proxy listeners, so an
+    /// exported config must not carry it — exports get attached to bug reports.
+    func testSanitizedForExportClearsTheLocalProxySecret() throws {
+        var cfg = RouteManager.Config()
+        cfg.localProxySecret = "deadbeefcafe"
+        let sanitized = cfg.sanitizedForExport()
+        XCTAssertNil(sanitized.localProxySecret)
+        XCTAssertEqual(cfg.localProxySecret, "deadbeefcafe", "the running app keeps its own secret")
+        let json = String(data: try JSONEncoder().encode(sanitized), encoding: .utf8)!
+        XCTAssertFalse(json.contains("deadbeefcafe"))
+    }
+
+
     func testSanitizedForExportClearsAllCredentials() throws {
         var cfg = RouteManager.Config()
         cfg.proxyConfig.enabled = true

--- a/Tests/VPNBypassTests/HookGeneratorEdgeCaseTests.swift
+++ b/Tests/VPNBypassTests/HookGeneratorEdgeCaseTests.swift
@@ -39,8 +39,8 @@ final class HookGeneratorEdgeCaseTests: XCTestCase {
     /// The maximum UInt16 port value must be embedded correctly, with no truncation or
     /// overflow surprises in the generated proxy URL.
     func testShellExportsWithMaxPortValue() {
-        let s = HookGenerator.shellExports(port: 65535)
-        XCTAssertTrue(s.contains("HTTPS_PROXY=\"http://127.0.0.1:65535\""))
-        XCTAssertTrue(s.contains("HTTP_PROXY=\"http://127.0.0.1:65535\""))
+        let s = HookGenerator.shellExports(port: 65535, secret: "s3cr3t")
+        XCTAssertTrue(s.contains("HTTPS_PROXY=\"http://vpnb:s3cr3t@127.0.0.1:65535\""))
+        XCTAssertTrue(s.contains("HTTP_PROXY=\"http://vpnb:s3cr3t@127.0.0.1:65535\""))
     }
 }

--- a/Tests/VPNBypassTests/HookGeneratorTests.swift
+++ b/Tests/VPNBypassTests/HookGeneratorTests.swift
@@ -10,9 +10,9 @@ import JavaScriptCore
 final class HookGeneratorTests: XCTestCase {
 
     func testShellExportsContainsListenerAndNoProxy() {
-        let s = HookGenerator.shellExports(port: 18101)
-        XCTAssertTrue(s.contains("HTTPS_PROXY=\"http://127.0.0.1:18101\""))
-        XCTAssertTrue(s.contains("http_proxy=\"http://127.0.0.1:18101\""))
+        let s = HookGenerator.shellExports(port: 18101, secret: "s3cr3t")
+        XCTAssertTrue(s.contains("HTTPS_PROXY=\"http://vpnb:s3cr3t@127.0.0.1:18101\""))
+        XCTAssertTrue(s.contains("http_proxy=\"http://vpnb:s3cr3t@127.0.0.1:18101\""))
         XCTAssertTrue(s.contains("NO_PROXY=\"localhost,127.0.0.1,::1\""))
     }
 

--- a/Tests/VPNBypassTests/LoopbackPeerAuthTests.swift
+++ b/Tests/VPNBypassTests/LoopbackPeerAuthTests.swift
@@ -1,0 +1,52 @@
+import Darwin
+import Network
+import XCTest
+@testable import VPNBypassCore
+
+final class LoopbackPeerAuthTests: XCTestCase {
+
+    func testAllowsRejectsNilPeer() {
+        XCTAssertFalse(LoopbackPeerAuth.allows(peerUID: nil),
+                       "unknown peer must fail closed")
+    }
+
+    func testAllowsAcceptsSameUid() {
+        XCTAssertTrue(LoopbackPeerAuth.allows(peerUID: getuid()))
+    }
+
+    func testAllowsRejectsOtherUid() {
+        let other = getuid() &+ 1
+        XCTAssertFalse(LoopbackPeerAuth.allows(peerUID: other),
+                       "a different uid must be rejected")
+    }
+
+    func testUidLookupFindsOwnListeningPort() throws {
+        let listener = try NWListener(using: .tcp)
+        let ready = expectation(description: "listener ready")
+        var bound: UInt16 = 0
+        listener.stateUpdateHandler = { state in
+            if case .ready = state, let port = listener.port?.rawValue {
+                bound = port
+                ready.fulfill()
+            }
+        }
+        listener.newConnectionHandler = { _ in }
+        listener.start(queue: DispatchQueue(label: "test.loopback.peer.listener"))
+        defer { listener.cancel() }
+        wait(for: [ready], timeout: 5.0)
+        XCTAssertNotEqual(bound, 0)
+
+        let uid = try XCTUnwrap(LoopbackPeerAuth.uidOwningLocalTCPPort(bound),
+                                "libproc must see this process's listen socket")
+        XCTAssertEqual(uid, getuid())
+    }
+
+    func testUidLookupReturnsNilForUnusedPort() {
+        // Port 1 is TCPMUX and is not bound by this test process. Lookup
+        // either finds nothing or (if something else owns it) a uid. The
+        // unused-port contract is: if we cannot name a single owner, nil.
+        // Bind-and-close a high port then look it up after close is racy,
+        // so we only assert that port 0 is rejected by the C helper.
+        XCTAssertNil(LoopbackPeerAuth.uidOwningLocalTCPPort(0))
+    }
+}

--- a/Tests/VPNBypassTests/ProxyForwarderTests.swift
+++ b/Tests/VPNBypassTests/ProxyForwarderTests.swift
@@ -567,6 +567,61 @@ final class ProxyForwarderTests: XCTestCase {
         try assertMalformedConnectAuthorityReturns400(authority: "evil.com:443\u{7F}X:1")
     }
 
+    /// NEL (U+0085). Its UTF-8 bytes are C2 85 — no 0x0A, no 0x0D — so a byte-oriented
+    /// upstream parser does not break on it. One that decodes to text first does:
+    /// Python's `str.splitlines()` splits on it, `bytes.splitlines()` does not. We cannot
+    /// know which is upstream, so it must not reach the wire.
+    func testConnectAuthorityWithNELReturns400() throws {
+        try assertMalformedConnectAuthorityReturns400(authority: "evil.com:443\u{85}X:1")
+    }
+
+    /// LINE SEPARATOR (U+2028) — same reasoning as NEL, UTF-8 bytes E2 80 A8.
+    func testConnectAuthorityWithLineSeparatorReturns400() throws {
+        try assertMalformedConnectAuthorityReturns400(authority: "evil.com:443\u{2028}X:1")
+    }
+
+    /// PARAGRAPH SEPARATOR (U+2029) — same reasoning as NEL, UTF-8 bytes E2 80 A9.
+    func testConnectAuthorityWithParagraphSeparatorReturns400() throws {
+        try assertMalformedConnectAuthorityReturns400(authority: "evil.com:443\u{2029}X:1")
+    }
+
+    /// The guard stops at line-break-capable characters: an IDN host carries non-ASCII
+    /// that is not a break under ANY parser, so it must still be accepted and dialed
+    /// verbatim. This pins the deliberate decision not to blanket-reject non-ASCII, so a
+    /// later tightening has to break this test rather than break a user's route silently.
+    func testConnectAuthorityWithNonASCIIIDNHostIsStillAccepted() throws {
+        let mockReady = expectation(description: "capturing mock ready")
+        let gotHead = expectation(description: "mock captured the CONNECT head")
+
+        var mockPort: UInt16 = 0
+        try startCapturingHTTPMock(onHead: { head in
+            XCTAssertTrue(head.hasPrefix("CONNECT b\u{FC}cher.example:443 HTTP/1.1\r\n"),
+                          "a non-ASCII host must still reach the upstream verbatim: \(head)")
+            gotHead.fulfill()
+        }, ready: { port in mockPort = port; mockReady.fulfill() })
+        wait(for: [mockReady], timeout: 5.0)
+        XCTAssertNotEqual(mockPort, 0)
+
+        let forwarder = ProxyForwarder(
+            listenPort: 0,
+            upstream: .init(host: "127.0.0.1", port: mockPort, username: "", password: "", boundInterface: nil)
+        )
+        try forwarder.start()
+        self.forwarder = forwarder
+        let listenPort = try XCTUnwrap(forwarder.boundPort)
+
+        let client = NWConnection(host: "127.0.0.1", port: NWEndpoint.Port(rawValue: listenPort)!, using: .tcp)
+        self.clientConnection = client
+        client.stateUpdateHandler = { state in
+            if case .ready = state {
+                let request = "CONNECT b\u{FC}cher.example:443 HTTP/1.1\r\nHost: b\u{FC}cher.example:443\r\n\r\n"
+                client.send(content: Data(request.utf8), completion: .contentProcessed { _ in })
+            }
+        }
+        client.start(queue: clientQueue)
+        wait(for: [gotHead], timeout: 5.0)
+    }
+
     /// End-to-end property, independent of WHICH layer enforces it: a client that embeds a
     /// full CR LF pair in its CONNECT line must never get an extra header onto the
     /// authenticated upstream hop. Today processClientHead truncates the request line at

--- a/Tests/VPNBypassTests/ProxyForwarderTests.swift
+++ b/Tests/VPNBypassTests/ProxyForwarderTests.swift
@@ -526,6 +526,147 @@ final class ProxyForwarderTests: XCTestCase {
         try assertMalformedConnectAuthorityReturns400(authority: "[2001:db8::1]")
     }
 
+    // MARK: - Local-caller authentication (GHSA-gm4h-95p9-9w7v, listener half)
+
+    // The listener is plain TCP on 127.0.0.1 and macOS exposes no peer uid for that, so the
+    // owner is identified by a secret only the owner can read (0600 config -> generated
+    // exports). Until a client proves it holds that secret we must not dial out and must not
+    // spend the owner's upstream credentials.
+
+    private static let testSecret = "s3cr3t"
+    private var authHeader: String { "Proxy-Authorization: Basic " + Data("vpnb:\(Self.testSecret)".utf8).base64EncodedString() }
+
+    /// No credential at all -> 407, and crucially nothing is dialed upstream.
+    func testConnectWithoutLocalSecretReturns407() throws {
+        try assertLocalAuth(clientAuthLine: nil, expect: "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"VPN Bypass\"\r\n\r\n")
+    }
+
+    /// A wrong credential is refused exactly like a missing one.
+    func testConnectWithWrongLocalSecretReturns407() throws {
+        let wrong = "Proxy-Authorization: Basic " + Data("vpnb:not-the-secret".utf8).base64EncodedString()
+        try assertLocalAuth(clientAuthLine: wrong, expect: "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"VPN Bypass\"\r\n\r\n")
+    }
+
+    /// A non-Basic scheme must not be accepted just because the header is present.
+    func testConnectWithNonBasicSchemeReturns407() throws {
+        try assertLocalAuth(clientAuthLine: "Proxy-Authorization: Bearer " + Self.testSecret,
+                            expect: "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"VPN Bypass\"\r\n\r\n")
+    }
+
+    /// Shared driver: a forwarder WITH a secret, pointed at a dead upstream port. If the
+    /// tunnel were opened we would never see a 407, so the assertion doubles as proof that
+    /// nothing was dialed.
+    private func assertLocalAuth(clientAuthLine: String?, expect: String) throws {
+        let got = expectation(description: "client received the expected refusal")
+        let forwarder = ProxyForwarder(
+            listenPort: 0,
+            upstream: .init(host: "127.0.0.1", port: 1, username: "up", password: "pw", boundInterface: nil),
+            localSecret: Self.testSecret
+        )
+        try forwarder.start()
+        self.forwarder = forwarder
+        let listenPort = try XCTUnwrap(forwarder.boundPort)
+
+        let client = NWConnection(host: "127.0.0.1", port: NWEndpoint.Port(rawValue: listenPort)!, using: .tcp)
+        self.clientConnection = client
+        client.stateUpdateHandler = { [weak self] state in
+            guard let self = self else { return }
+            if case .ready = state {
+                var request = "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n"
+                if let line = clientAuthLine { request += line + "\r\n" }
+                request += "\r\n"
+                client.send(content: Data(request.utf8), completion: .contentProcessed { _ in })
+                self.receiveStatusHead(client, expected: expect, fulfill: got)
+            }
+        }
+        client.start(queue: clientQueue)
+        wait(for: [got], timeout: 5.0)
+    }
+
+    /// The correct secret opens the tunnel, and the LOCAL credential must not leak upstream:
+    /// the upstream sees exactly one Proxy-Authorization and it is the UPSTREAM's.
+    func testCorrectLocalSecretDialsUpstreamAndDoesNotForwardTheLocalCredential() throws {
+        let mockReady = expectation(description: "capturing mock ready")
+        let gotHead = expectation(description: "mock captured the CONNECT head")
+
+        var mockPort: UInt16 = 0
+        try startCapturingHTTPMock(onHead: { head in
+            let upstreamToken = Data("up:pw".utf8).base64EncodedString()
+            let localToken = Data("vpnb:\(Self.testSecret)".utf8).base64EncodedString()
+            XCTAssertTrue(head.contains("Proxy-Authorization: Basic \(upstreamToken)"),
+                          "the upstream's own credential must be present: \(head)")
+            XCTAssertFalse(head.contains(localToken),
+                           "the LOCAL hop secret must never be forwarded upstream: \(head)")
+            XCTAssertEqual(head.components(separatedBy: "Proxy-Authorization:").count - 1, 1,
+                           "exactly one Proxy-Authorization may reach the upstream: \(head)")
+            gotHead.fulfill()
+        }, ready: { port in mockPort = port; mockReady.fulfill() })
+        wait(for: [mockReady], timeout: 5.0)
+
+        let forwarder = ProxyForwarder(
+            listenPort: 0,
+            upstream: .init(host: "127.0.0.1", port: mockPort, username: "up", password: "pw", boundInterface: nil),
+            localSecret: Self.testSecret
+        )
+        try forwarder.start()
+        self.forwarder = forwarder
+        let listenPort = try XCTUnwrap(forwarder.boundPort)
+
+        let client = NWConnection(host: "127.0.0.1", port: NWEndpoint.Port(rawValue: listenPort)!, using: .tcp)
+        self.clientConnection = client
+        client.stateUpdateHandler = { [weak self] state in
+            guard let self = self else { return }
+            if case .ready = state {
+                let request = "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n"
+                    + self.authHeader + "\r\n\r\n"
+                client.send(content: Data(request.utf8), completion: .contentProcessed { _ in })
+            }
+        }
+        client.start(queue: clientQueue)
+        wait(for: [gotHead], timeout: 5.0)
+    }
+
+    /// Same guarantee on the NON-CONNECT path, which forwards the client's head verbatim and
+    /// is the wider hole: it staples the owner's credential onto any absolute-URI request.
+    func testPlainPathStripsTheClientCredentialBeforeForwarding() throws {
+        let mockReady = expectation(description: "capturing mock ready")
+        let gotHead = expectation(description: "mock captured the plain head")
+
+        var mockPort: UInt16 = 0
+        try startCapturingHTTPMock(onHead: { head in
+            let localToken = Data("vpnb:\(Self.testSecret)".utf8).base64EncodedString()
+            XCTAssertFalse(head.contains(localToken),
+                           "the local secret must not be forwarded on the plain path: \(head)")
+            XCTAssertEqual(head.components(separatedBy: "Proxy-Authorization:").count - 1, 1,
+                           "exactly one Proxy-Authorization may reach the upstream: \(head)")
+            XCTAssertTrue(head.contains("X-Keep: yes"), "unrelated headers must survive: \(head)")
+            gotHead.fulfill()
+        }, ready: { port in mockPort = port; mockReady.fulfill() })
+        wait(for: [mockReady], timeout: 5.0)
+
+        let forwarder = ProxyForwarder(
+            listenPort: 0,
+            upstream: .init(host: "127.0.0.1", port: mockPort, username: "up", password: "pw", boundInterface: nil),
+            localSecret: Self.testSecret
+        )
+        try forwarder.start()
+        self.forwarder = forwarder
+        let listenPort = try XCTUnwrap(forwarder.boundPort)
+
+        let client = NWConnection(host: "127.0.0.1", port: NWEndpoint.Port(rawValue: listenPort)!, using: .tcp)
+        self.clientConnection = client
+        client.stateUpdateHandler = { [weak self] state in
+            guard let self = self else { return }
+            if case .ready = state {
+                let request = "GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\n"
+                    + self.authHeader + "\r\nX-Keep: yes\r\n\r\n"
+                client.send(content: Data(request.utf8), completion: .contentProcessed { _ in })
+            }
+        }
+        client.start(queue: clientQueue)
+        wait(for: [gotHead], timeout: 5.0)
+    }
+
     // MARK: - CONNECT authority header injection (GHSA-gm4h-95p9-9w7v)
 
     // The authority is interpolated verbatim into BOTH the request line and the `Host:`

--- a/Tests/VPNBypassTests/ProxyForwarderTests.swift
+++ b/Tests/VPNBypassTests/ProxyForwarderTests.swift
@@ -526,6 +526,90 @@ final class ProxyForwarderTests: XCTestCase {
         try assertMalformedConnectAuthorityReturns400(authority: "[2001:db8::1]")
     }
 
+    // MARK: - CONNECT authority header injection (GHSA-gm4h-95p9-9w7v)
+
+    // The authority is interpolated verbatim into BOTH the request line and the `Host:`
+    // header that connectRequest() sends upstream, on a hop that carries the owner's
+    // `Proxy-Authorization: Basic`. processClientHead cuts the client's request line at
+    // the first CR LF pair, so a *paired* CRLF cannot reach isValidAuthority — but a LONE
+    // LF, a LONE CR, and every other C0 control survive that cut, and a lenient upstream
+    // proxy treats a bare LF (and often a bare CR) as a line terminator. That is enough to
+    // append attacker-chosen headers, or a whole second request, to an authenticated
+    // upstream connection. Each of these must fail closed with 400 before any dial-out.
+
+    /// A LONE LF inside the authority: the reachable injection primitive. Without the
+    /// guard the upstream receives "CONNECT evil.com:443\nX-Injected:1 HTTP/1.1" followed
+    /// by the owner's Proxy-Authorization.
+    func testConnectAuthorityWithBareLineFeedReturns400() throws {
+        try assertMalformedConnectAuthorityReturns400(authority: "evil.com:443\nX-Injected:1")
+    }
+
+    /// A LONE CR: same primitive against upstreams that accept a bare CR as a line break.
+    func testConnectAuthorityWithBareCarriageReturnReturns400() throws {
+        try assertMalformedConnectAuthorityReturns400(authority: "evil.com:443\rX-Injected:1")
+    }
+
+    /// NUL: truncates the authority for any C-string consumer downstream of the proxy.
+    func testConnectAuthorityWithNULReturns400() throws {
+        try assertMalformedConnectAuthorityReturns400(authority: "evil.com:443\u{0}X:1")
+    }
+
+    /// TAB is not a line break, so it cannot split a header — but it IS forbidden in a
+    /// request-target and is header-value whitespace, so it must not reach the wire either.
+    /// A CR/LF/NUL-only blocklist lets this through.
+    func testConnectAuthorityWithTabReturns400() throws {
+        try assertMalformedConnectAuthorityReturns400(authority: "evil.com:443\tX:1")
+    }
+
+    /// DEL (0x7F) is a control character that is likewise illegal in a request-target and
+    /// likewise survives a CR/LF/NUL-only blocklist.
+    func testConnectAuthorityWithDELReturns400() throws {
+        try assertMalformedConnectAuthorityReturns400(authority: "evil.com:443\u{7F}X:1")
+    }
+
+    /// End-to-end property, independent of WHICH layer enforces it: a client that embeds a
+    /// full CR LF pair in its CONNECT line must never get an extra header onto the
+    /// authenticated upstream hop. Today processClientHead truncates the request line at
+    /// that pair, so the CONNECT dialed upstream is the clean prefix and the injected text
+    /// is discarded with the rest of the client's head. This asserts the observable
+    /// outcome, so it stays meaningful if that truncation is ever refactored away — which
+    /// matters because Swift treats CR LF as ONE Character that equals neither "\r" nor
+    /// "\n", so a Character-level blocklist would silently pass the pair.
+    func testConnectAuthorityWithCRLFPairNeverInjectsAHeaderUpstream() throws {
+        let mockReady = expectation(description: "capturing mock ready")
+        let gotHead = expectation(description: "mock captured the CONNECT head")
+
+        var mockPort: UInt16 = 0
+        try startCapturingHTTPMock(onHead: { head in
+            XCTAssertFalse(head.contains("X-Injected"),
+                           "no client-supplied header may reach the authenticated upstream hop: \(head)")
+            XCTAssertTrue(head.hasPrefix("CONNECT evil.com:443 HTTP/1.1\r\n"),
+                          "the upstream CONNECT must carry only the clean authority: \(head)")
+            gotHead.fulfill()
+        }, ready: { port in mockPort = port; mockReady.fulfill() })
+        wait(for: [mockReady], timeout: 5.0)
+        XCTAssertNotEqual(mockPort, 0)
+
+        let forwarder = ProxyForwarder(
+            listenPort: 0,
+            upstream: .init(host: "127.0.0.1", port: mockPort, username: "", password: "", boundInterface: nil)
+        )
+        try forwarder.start()
+        self.forwarder = forwarder
+        let listenPort = try XCTUnwrap(forwarder.boundPort)
+
+        let client = NWConnection(host: "127.0.0.1", port: NWEndpoint.Port(rawValue: listenPort)!, using: .tcp)
+        self.clientConnection = client
+        client.stateUpdateHandler = { state in
+            if case .ready = state {
+                let request = "CONNECT evil.com:443\r\nX-Injected:1 HTTP/1.1\r\nHost: evil.com:443\r\n\r\n"
+                client.send(content: Data(request.utf8), completion: .contentProcessed { _ in })
+            }
+        }
+        client.start(queue: clientQueue)
+        wait(for: [gotHead], timeout: 5.0)
+    }
+
     /// Shared driver for the 400-path tests above: no mock upstream is needed since
     /// isValidAuthority rejects before the forwarder ever dials out (mirrors the
     /// existing testMalformedConnectAuthorityReturns400, which covers a non-numeric port).

--- a/Tests/VPNBypassTests/ProxyListenerManagerTests.swift
+++ b/Tests/VPNBypassTests/ProxyListenerManagerTests.swift
@@ -194,4 +194,17 @@ final class ProxyListenerManagerTests: XCTestCase {
         XCTAssertNotNil(manager.port(for: ts.id), "a Tailscale-peer route gets a loopback listener")
         manager.stopAll()
     }
+
+    /// A live ProxyForwarder captures localSecret at init and cannot be re-pointed, so the
+    /// secret belongs in the listener's identity: a rotated secret must restart it, or the
+    /// old credential keeps working and newly copied exports get a 407.
+    func testUpstreamFingerprintChangesWhenTheLocalSecretChanges() {
+        var route = Route(name: "p", egress: .proxyHTTP)
+        route.proxyHost = "h"; route.proxyPort = 8001
+        let a = ProxyListenerManager.upstreamFingerprint(route, boundInterface: nil, localSecret: "one")
+        let b = ProxyListenerManager.upstreamFingerprint(route, boundInterface: nil, localSecret: "two")
+        XCTAssertNotEqual(a, b)
+        XCTAssertEqual(a, ProxyListenerManager.upstreamFingerprint(route, boundInterface: nil, localSecret: "one"))
+    }
+
 }


### PR DESCRIPTION
A proxy route's `127.0.0.1` listener held my upstream proxy credentials and served anyone who found the port — and the port is derived from the route id, so finding it is trivial. Any other account on this machine could push traffic through my paid proxy on my identity, and on the non-CONNECT path could do it to any destination, not only the ones I'd configured. A second hole let a local client put a bare LF in the `CONNECT` authority and staple extra headers onto that same authenticated connection.

The listener now asks for a password before it spends anything: a per-install secret from the 0600 config, handed to clients in the generated exports, plus a same-uid check on the peer. The CONNECT authority rejects every character a proxy could read as a line break, whether it parses bytes or decoded text.

Reported privately by Sebastien Tardif through GHSA-gm4h-95p9-9w7v, who also wrote the first CONNECT guard and the same-uid gate.

This ships as 4.7.0 rather than a patch: it adds a config field, and any proxy address copied before this release stops working. The README says what to re-copy and troubleshooting now names the 407. Listeners run in Custom mode as well as behind the experimental multi-route flag, so it reaches people who never opted into anything experimental.

Worth pushing back on if you disagree: `accept` starts the connection and `Tunnel.start()` starts it again. It works and the end-to-end relay tests pass, but it leans on Network.framework tolerating a second start rather than on anything documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authentication for local proxy connections using automatically generated credentials.
  - Shell proxy exports now include authenticated URLs.
  - Unauthorized requests receive a `407 Proxy Authentication Required` response.
- **Security**
  - Improved validation for proxy CONNECT requests and removed local credentials before forwarding.
  - Added fail-closed verification that local connections originate from the expected process.
- **Documentation**
  - Added setup and troubleshooting guidance for credential-protected proxy listeners.
- **Tests**
  - Added coverage for authentication, credential handling, connection validation, and malformed proxy requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->