### PR TITLE
fix: bound the helper DNS flush so a wedged child cannot hang it

### DIFF
--- a/Helper/HelperTool.swift
+++ b/Helper/HelperTool.swift
@@ -484,29 +484,27 @@ class HelperTool: NSObject, HelperProtocol {
     }
     
     func flushDNSCache(withReply reply: @escaping (Bool) -> Void) {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/dscacheutil")
-        process.arguments = ["-flushcache"]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        
-        do {
-            try process.run()
-            process.waitUntilExit()
-            
-            // Also run killall -HUP mDNSResponder for good measure
-            let mdnsProcess = Process()
-            mdnsProcess.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
-            mdnsProcess.arguments = ["-HUP", "mDNSResponder"]
-            mdnsProcess.standardOutput = FileHandle.nullDevice
-            mdnsProcess.standardError = FileHandle.nullDevice
-            try? mdnsProcess.run()
-            mdnsProcess.waitUntilExit()
-            
-            reply(true)
-        } catch {
-            reply(false)
+        // Best-effort: the app ignores this Bool and already recorded the hosts
+        // write as success. A wedged child must not park this XPC thread.
+        let dscache = Process()
+        dscache.executableURL = URL(fileURLWithPath: "/usr/bin/dscacheutil")
+        dscache.arguments = ["-flushcache"]
+        dscache.standardOutput = FileHandle.nullDevice
+        dscache.standardError = FileHandle.nullDevice
+        if !ProcessDeadline.run(dscache) {
+            helperLog.error("dscacheutil -flushcache did not finish in time; killed")
         }
+
+        let mdns = Process()
+        mdns.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
+        mdns.arguments = ["-HUP", "mDNSResponder"]
+        mdns.standardOutput = FileHandle.nullDevice
+        mdns.standardError = FileHandle.nullDevice
+        if !ProcessDeadline.run(mdns) {
+            helperLog.error("killall -HUP mDNSResponder did not finish in time; killed")
+        }
+
+        reply(true)
     }
     
     // MARK: - Version

--- a/Helper/HelperTool.swift
+++ b/Helper/HelperTool.swift
@@ -491,19 +491,17 @@ class HelperTool: NSObject, HelperProtocol {
         dscache.arguments = ["-flushcache"]
         dscache.standardOutput = FileHandle.nullDevice
         dscache.standardError = FileHandle.nullDevice
-        if !ProcessDeadline.run(dscache) {
-            helperLog.error("dscacheutil -flushcache did not finish in time; killed")
-        }
+        logFlushOutcome("dscacheutil -flushcache", ProcessDeadline.run(dscache))
 
         let mdns = Process()
         mdns.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
         mdns.arguments = ["-HUP", "mDNSResponder"]
         mdns.standardOutput = FileHandle.nullDevice
         mdns.standardError = FileHandle.nullDevice
-        if !ProcessDeadline.run(mdns) {
-            helperLog.error("killall -HUP mDNSResponder did not finish in time; killed")
-        }
+        logFlushOutcome("killall -HUP mDNSResponder", ProcessDeadline.run(mdns))
 
+        // Hosts write already succeeded; the app ignores this Bool. A
+        // nonzero killall (no matching process) must not fail the update.
         reply(true)
     }
     
@@ -511,6 +509,19 @@ class HelperTool: NSObject, HelperProtocol {
     
     func getVersion(withReply reply: @escaping (String) -> Void) {
         reply(HelperConstants.helperVersion)
+    }
+
+    private func logFlushOutcome(_ name: String, _ outcome: ProcessDeadline.Outcome) {
+        switch outcome {
+        case .failedToStart:
+            helperLog.error("\(name, privacy: .public) failed to start")
+        case .timedOut:
+            helperLog.error("\(name, privacy: .public) did not finish in time; killed")
+        case .exited(let code) where code != 0:
+            helperLog.error("\(name, privacy: .public) exited \(code, privacy: .public)")
+        case .exited:
+            break
+        }
     }
     
     // MARK: - Validation

--- a/Helper/Info.plist
+++ b/Helper/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleName</key>
 	<string>VPNBypassHelper</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>SMAuthorizedClients</key>
 	<array>
 		<string>identifier "com.geiserx.vpn-bypass"</string>

--- a/Sources/VPNBypassCore/HelperProtocol.swift
+++ b/Sources/VPNBypassCore/HelperProtocol.swift
@@ -1,6 +1,7 @@
 // HelperProtocol.swift
 // XPC Protocol shared between main app and privileged helper.
 
+import Darwin
 import Foundation
 
 /// The bundle ID for the privileged helper tool
@@ -118,7 +119,11 @@ struct HelperConstants {
     // concurrent `route -n get` — observed as GlobalProtect's gateway-route read timing out
     // seconds after our batch and tearing the tunnel down. A 200ms pause every 32 writes keeps
     // any listener's backlog under one buffer. Bumped so installed helpers pick this up.
-    static let helperVersion = "2.1.0"
+    // 2.1.1: flushDNSCache bounds dscacheutil / killall -HUP mDNSResponder (3s each) instead
+    // of waitUntilExit() with no deadline. A wedged child used to park the XPC thread for
+    // the life of the daemon after the app had already dropped the 30s hosts-update
+    // connection. Bumped so installed 2.1.0 helpers reinstall and pick this up.
+    static let helperVersion = "2.1.1"
     static let bundleID = "com.geiserx.vpnbypass.helper"
     static let hostMarkerStart = "# VPN-BYPASS-MANAGED - START"
     static let hostMarkerEnd = "# VPN-BYPASS-MANAGED - END"
@@ -396,5 +401,67 @@ public enum VPNInterfaceSelector {
             }
         }
         return nil
+    }
+}
+
+// MARK: - Process deadline (pure, testable seam)
+
+/// Bounded wait around `Foundation.Process`. Lives in this file so the helper
+/// binary (`make build-helper` compiles this source) and the test target share
+/// one implementation (same reason as `HelperAuthPolicy` / `RouteCIDR`).
+///
+/// The app already bounds every subprocess via `DNSResolver.runProcessSyncSafe`.
+/// The privileged helper's DNS flush still used unbounded `waitUntilExit()`.
+enum ProcessDeadline {
+    /// Long enough for `dscacheutil -flushcache` / `killall -HUP mDNSResponder`
+    /// on a healthy box; short enough that two sequential flushes stay well
+    /// under the app's 30s hosts-update XPC deadline.
+    static let defaultSeconds: TimeInterval = 3
+
+    /// Launch `process` and wait up to `seconds`. Returns `true` if the child
+    /// exited on its own, `false` if it failed to start or was still running
+    /// at the deadline (in which case it is sent SIGTERM and reaped).
+    @discardableResult
+    static func run(_ process: Process, seconds: TimeInterval = defaultSeconds) -> Bool {
+        do {
+            try process.run()
+        } catch {
+            return false
+        }
+        // Same 10ms poll as `DNSResolver.runProcessSyncSafe`: a nested GCD
+        // semaphore on the helper's XPC thread has deadlocked this process
+        // runner before; a deadline loop does not.
+        let deadline = Date().addingTimeInterval(seconds)
+        while process.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        if process.isRunning {
+            process.terminate()
+            let grace = Date().addingTimeInterval(1)
+            while process.isRunning && Date() < grace {
+                Thread.sleep(forTimeInterval: 0.01)
+            }
+            if process.isRunning {
+                // SIGTERM is ignorable. A wedged dscacheutil that ignored it
+                // would recreate the original hang on waitUntilExit.
+                kill(process.processIdentifier, SIGKILL)
+                let reap = Date().addingTimeInterval(0.5)
+                while process.isRunning && Date() < reap {
+                    Thread.sleep(forTimeInterval: 0.01)
+                }
+            }
+            return false
+        }
+        return true
+    }
+
+    @discardableResult
+    static func run(path: String, arguments: [String] = [], seconds: TimeInterval = defaultSeconds) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        process.arguments = arguments
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        return run(process, seconds: seconds)
     }
 }

--- a/Sources/VPNBypassCore/HelperProtocol.swift
+++ b/Sources/VPNBypassCore/HelperProtocol.swift
@@ -418,50 +418,58 @@ enum ProcessDeadline {
     /// under the app's 30s hosts-update XPC deadline.
     static let defaultSeconds: TimeInterval = 3
 
-    /// Launch `process` and wait up to `seconds`. Returns `true` if the child
-    /// exited on its own, `false` if it failed to start or was still running
-    /// at the deadline (in which case it is sent SIGTERM and reaped).
+    /// How `run` finished. Distinguishes a timely exit (with status) from a
+    /// start failure or a kill, so the helper can log nonzero exits.
+    enum Outcome: Equatable {
+        case failedToStart
+        case timedOut
+        case exited(Int32)
+    }
+
+    /// Launch `process` and wait up to `seconds`. Deadlines use `DispatchTime`
+    /// (monotonic) so a wall-clock step backward cannot stretch the wait.
     @discardableResult
-    static func run(_ process: Process, seconds: TimeInterval = defaultSeconds) -> Bool {
+    static func run(_ process: Process, seconds: TimeInterval = defaultSeconds) -> Outcome {
         do {
             try process.run()
         } catch {
-            return false
+            return .failedToStart
         }
         // Same 10ms poll as `DNSResolver.runProcessSyncSafe`: a nested GCD
         // semaphore on the helper's XPC thread has deadlocked this process
         // runner before; a deadline loop does not.
-        let deadline = Date().addingTimeInterval(seconds)
-        while process.isRunning && Date() < deadline {
-            Thread.sleep(forTimeInterval: 0.01)
-        }
+        waitUntilNotRunning(process, seconds: seconds)
         if process.isRunning {
             process.terminate()
-            let grace = Date().addingTimeInterval(1)
-            while process.isRunning && Date() < grace {
-                Thread.sleep(forTimeInterval: 0.01)
-            }
+            waitUntilNotRunning(process, seconds: 1)
             if process.isRunning {
                 // SIGTERM is ignorable. A wedged dscacheutil that ignored it
                 // would recreate the original hang on waitUntilExit.
                 kill(process.processIdentifier, SIGKILL)
-                let reap = Date().addingTimeInterval(0.5)
-                while process.isRunning && Date() < reap {
-                    Thread.sleep(forTimeInterval: 0.01)
-                }
+                waitUntilNotRunning(process, seconds: 0.5)
             }
-            return false
+            return .timedOut
         }
-        return true
+        return .exited(process.terminationStatus)
     }
 
     @discardableResult
-    static func run(path: String, arguments: [String] = [], seconds: TimeInterval = defaultSeconds) -> Bool {
+    static func run(path: String, arguments: [String] = [], seconds: TimeInterval = defaultSeconds) -> Outcome {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: path)
         process.arguments = arguments
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
         return run(process, seconds: seconds)
+    }
+
+    /// Poll `isRunning` until the child exits or `seconds` of monotonic
+    /// time elapse. Never uses `Date()`, which can move backward.
+    private static func waitUntilNotRunning(_ process: Process, seconds: TimeInterval) {
+        let ns = max(0, seconds) * 1_000_000_000
+        let deadline = DispatchTime.now() + .nanoseconds(Int(ns.rounded()))
+        while process.isRunning && DispatchTime.now() < deadline {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
     }
 }

--- a/Tests/VPNBypassTests/ProcessDeadlineTests.swift
+++ b/Tests/VPNBypassTests/ProcessDeadlineTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import VPNBypassCore
+
+/// Coverage for `ProcessDeadline`, the helper's bounded `Process` wait.
+///
+/// `flushDNSCache` used to call `waitUntilExit()` with no deadline. A wedged
+/// `dscacheutil` or `killall` parked the XPC thread for the life of the daemon
+/// after the app had already dropped the 30s hosts-update connection. This
+/// seam is compiled into both the helper and the test target (same reason as
+/// `HelperAuthPolicy` / `RouteCIDR`).
+final class ProcessDeadlineTests: XCTestCase {
+
+    func testFinishedProcessReturnsTrue() {
+        XCTAssertTrue(ProcessDeadline.run(path: "/usr/bin/true", seconds: 2))
+    }
+
+    /// A child that outlives the deadline must be killed and reported as a
+    /// timeout. Without a deadline this returns true after the sleep exits.
+    func testLongChildIsKilledAndReportedAsTimeout() {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["8"]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        XCTAssertFalse(
+            ProcessDeadline.run(process, seconds: 0.25),
+            "a child that outlives the deadline must return false, not wait it out"
+        )
+        XCTAssertFalse(process.isRunning, "timed-out child must not be left running")
+    }
+
+    func testMissingExecutableReturnsFalse() {
+        XCTAssertFalse(ProcessDeadline.run(path: "/no/such/vpnb-deadline-binary", seconds: 1))
+    }
+
+    /// SIGTERM is ignorable. The deadline path must escalate to SIGKILL so a
+    /// child that traps TERM cannot recreate the unbounded wait.
+    func testTermIgnoringChildIsKilled() {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", "trap '' TERM; exec /bin/sleep 8"]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        XCTAssertFalse(ProcessDeadline.run(process, seconds: 0.25))
+        XCTAssertFalse(process.isRunning, "TERM-ignoring child must be SIGKILL'd")
+    }
+}

--- a/Tests/VPNBypassTests/ProcessDeadlineTests.swift
+++ b/Tests/VPNBypassTests/ProcessDeadlineTests.swift
@@ -11,7 +11,11 @@ import XCTest
 final class ProcessDeadlineTests: XCTestCase {
 
     func testFinishedProcessReturnsTrue() {
-        XCTAssertTrue(ProcessDeadline.run(path: "/usr/bin/true", seconds: 2))
+        XCTAssertEqual(ProcessDeadline.run(path: "/usr/bin/true", seconds: 2), .exited(0))
+    }
+
+    func testNonzeroExitIsReported() {
+        XCTAssertEqual(ProcessDeadline.run(path: "/usr/bin/false", seconds: 2), .exited(1))
     }
 
     /// A child that outlives the deadline must be killed and reported as a
@@ -23,15 +27,16 @@ final class ProcessDeadlineTests: XCTestCase {
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
 
-        XCTAssertFalse(
+        XCTAssertEqual(
             ProcessDeadline.run(process, seconds: 0.25),
-            "a child that outlives the deadline must return false, not wait it out"
+            .timedOut,
+            "a child that outlives the deadline must time out, not wait it out"
         )
         XCTAssertFalse(process.isRunning, "timed-out child must not be left running")
     }
 
     func testMissingExecutableReturnsFalse() {
-        XCTAssertFalse(ProcessDeadline.run(path: "/no/such/vpnb-deadline-binary", seconds: 1))
+        XCTAssertEqual(ProcessDeadline.run(path: "/no/such/vpnb-deadline-binary", seconds: 1), .failedToStart)
     }
 
     /// SIGTERM is ignorable. The deadline path must escalate to SIGKILL so a
@@ -43,7 +48,7 @@ final class ProcessDeadlineTests: XCTestCase {
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
 
-        XCTAssertFalse(ProcessDeadline.run(process, seconds: 0.25))
+        XCTAssertEqual(ProcessDeadline.run(process, seconds: 0.25), .timedOut)
         XCTAssertFalse(process.isRunning, "TERM-ignoring child must be SIGKILL'd")
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A stuck DNS-cache flush can no longer hang the privileged helper.** After writing `/etc/hosts`, the helper waited forever for `dscacheutil -flushcache` and `killall -HUP mDNSResponder`. If either child wedged, that helper thread stayed blocked for the life of the daemon even after the app gave up at 30 seconds. Those two processes now have a 3-second deadline, then SIGTERM and SIGKILL if they do not exit.
 - **With two VPNs running, the app could pick the wrong one.** Several tunnels being up at once is ordinary — a corporate VPN alongside Tailscale — but the app took the first one it happened to see, which had nothing to do with which tunnel was carrying traffic. Because Tailscale usually appears earlier in that list, it could win, and in VPN Only mode the app would then install its rules to escape the wrong tunnel and send the other one's traffic straight out. It now prefers the tunnel actually carrying the default route, never picks Tailscale, keeps its choice stable while several remain valid, and breaks any remaining tie the same way every time.
+
+### Changed
+- Updating the helper to 2.1.1 asks for one admin prompt so already-installed helpers pick up the flush deadline.
 
 ## [3.1.13] - 2026-08-07
 


### PR DESCRIPTION
## Summary

Bound the privileged helper's DNS-cache flush so a wedged `dscacheutil` or `killall` cannot park an XPC thread for the life of the daemon.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## The problem

After a successful `/etc/hosts` write, `HelperManager.updateHostsFile` calls `flushDNSCache`. That helper method ran `dscacheutil -flushcache` and `killall -HUP mDNSResponder` with `waitUntilExit()` and no deadline.

If either child wedges:

1. The helper never replies on that XPC call.
2. The app hits its 30s hosts-update deadline, reports failure (even though `/etc/hosts` already wrote), and drops the connection.
3. The helper thread stays blocked until the daemon is restarted.

This is the leftover of a hang class this repo already shipped. Helper 1.9.0 bounded every `route` subprocess for the same reason; v2 replaced those with a PF_ROUTE socket. The flush was never updated.

Call chain: Settings / DNS refresh / quit cleanup writes hosts -> `HelperManager.updateHostsFile` (30s XPC) -> on success, `flushDNSCache`.

Introduced in [PR #1](https://github.com/GeiserX/VPN-Bypass/pull/1) ([`f509c9c8`](https://github.com/GeiserX/VPN-Bypass/commit/f509c9c858)), 2026-01-17.

Related: [#65](https://github.com/GeiserX/VPN-Bypass/issues/65) (unbounded helper waits starving other VPN clients), [#79](https://github.com/GeiserX/VPN-Bypass/pull/79) (route engine left `Process` behind), `DNSResolver.runProcessSyncSafe` (the app already bounds every other subprocess).

## The change

- `ProcessDeadline` lives in `HelperProtocol.swift` so the helper binary and the test target share one implementation (same reason as `HelperAuthPolicy` / `RouteCIDR`).
- 3s poll deadline, then SIGTERM, 1s grace, SIGKILL. No unbounded `waitUntilExit`.
- Helper version 2.1.0 to 2.1.1 so already-installed helpers reinstall.

`flushDNSCache` still replies `true` after both attempts. The app ignores the Bool (`flushDNSCache { _ in ... }`) and the hosts write already succeeded. The old `killall` path was already `try?`.

## Testing

From the code path (unit tests against `ProcessDeadline`; the helper target is not linked into the test bundle):

- `/usr/bin/true` returns true
- `/bin/sleep 8` with a 0.25s deadline returns false and is not left running
- `trap '' TERM; sleep 8` is SIGKILL'd (1.27s, not 8s)
- Missing executable returns false

Red step (stub was unbounded `waitUntilExit`):

```
testLongChildIsKilledAndReportedAsTimeout
XCTAssertFalse failed - a child that outlives the deadline must return false, not wait it out
failed (8.208 seconds)
```

Green step: the same test passed in 0.268 seconds.

`swift test --enable-code-coverage`: 1005 tests, 0 failures.
`make build-helper`: universal helper builds.

I did not run a live Homebrew reinstall or a VPN-connected hosts update.

## Checklist

- [x] Code builds (`swift test`, `make build-helper`)
- [x] No hardcoded credentials or secrets
- [x] Updated `docs/CHANGELOG.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DNS cache flushing now has a bounded three-second timeout, preventing the helper from hanging indefinitely.
  * Timed-out processes are terminated safely, including forced termination when necessary.
  * Failures such as startup errors, timeouts, and unsuccessful exits are now logged for improved troubleshooting.

* **Documentation**
  * Updated the changelog with timeout behavior and helper version details.

* **Chores**
  * Bumped the helper version to 2.1.1, requiring one administrator prompt for updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->