### PR TITLE
fix: persist primary vpn route

### DIFF
--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -27,6 +27,7 @@ final class RouteManager: ObservableObject {
     @Published var routeVerificationResults: [String: RouteVerificationResult] = [:]
     @Published var isLoading = true
     @Published private(set) var isApplyingRoutes = false
+    @Published var isConfigLoadFailed = false
 
     /// True once shutdown has begun. Checked by the operation gate (so no new route
     /// operation can start) and by the tracked batch-add wrapper (so an operation
@@ -168,6 +169,7 @@ final class RouteManager: ObservableObject {
         loadDNSCache()
         
         guard FileManager.default.fileExists(atPath: configURL.path) else {
+            isConfigLoadFailed = false
             log(.info, "Config file absent, using default config")
             config = Config()
             ensurePrimaryVPNRoute()
@@ -178,10 +180,12 @@ final class RouteManager: ObservableObject {
             let data = try Data(contentsOf: configURL)
             let loaded = try JSONDecoder().decode(Config.self, from: data)
             config = loaded
+            isConfigLoadFailed = false
             ensurePrimaryVPNRoute()
             mergeBuiltInServices()
             log(.info, "Config loaded")
         } catch {
+            isConfigLoadFailed = true
             log(.error, "Failed to load config from \(configURL.path): \(error.localizedDescription). Preserving file on disk.")
         }
     }
@@ -248,6 +252,10 @@ final class RouteManager: ObservableObject {
     }
 
     func saveConfig() {
+        guard !isConfigLoadFailed else {
+            log(.warning, "Config save blocked: config.json failed to load and is preserved on disk")
+            return
+        }
         do {
             try saveConfigThrowing()
         } catch {
@@ -256,15 +264,43 @@ final class RouteManager: ObservableObject {
     }
 
     func saveConfigThrowing() throws {
+        guard !isConfigLoadFailed else {
+            log(.warning, "Config save blocked: config.json failed to load and is preserved on disk")
+            throw NSError(domain: "VPNBypass", code: 1001, userInfo: [NSLocalizedDescriptionKey: "Configuration save blocked due to load failure"])
+        }
+
         // Daily backup - overwrite if older than 24 hours
-        createDailyBackupIfNeeded()
-        
+        try createDailyBackupIfNeededThrowing()
+
         let encoder = JSONEncoder()
         let data = try encoder.encode(config)
-        try data.write(to: configURL, options: .atomic)
-        // config.json can hold proxy credentials — keep it owner-only (0600), tightening
-        // any pre-existing 0644 file on every save.
-        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: configURL.path)
+
+        let dir = configURL.deletingLastPathComponent()
+        let tempURL = dir.appendingPathComponent("config.json.tmp-\(UUID().uuidString)")
+
+        // 1. Write data to temporary file
+        try data.write(to: tempURL, options: .atomic)
+
+        // 2. Set strict 0600 owner-only permissions BEFORE replacing target file
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tempURL.path)
+
+        // 3. Verify permissions on temporary file
+        let attrs = try FileManager.default.attributesOfItem(atPath: tempURL.path)
+        guard let permissions = attrs[.posixPermissions] as? NSNumber, permissions.uint16Value == 0o600 else {
+            try? FileManager.default.removeItem(at: tempURL)
+            throw NSError(domain: "VPNBypass", code: 1002, userInfo: [NSLocalizedDescriptionKey: "Failed to verify 0600 permissions on temporary config file"])
+        }
+
+        // 4. Atomically replace target configURL with the secured temporary file
+        if FileManager.default.fileExists(atPath: configURL.path) {
+            _ = try FileManager.default.replaceItemAt(configURL, withItemAt: tempURL)
+        } else {
+            try FileManager.default.moveItem(at: tempURL, to: configURL)
+        }
+
+        // 5. Ensure final destination permissions remain 0600
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: configURL.path)
+
         log(.info, "Config saved")
     }
 
@@ -272,6 +308,7 @@ final class RouteManager: ObservableObject {
     /// A nil selector is already the legacy primary-VPN representation.
     @discardableResult
     func ensurePrimaryVPNRoute() -> Bool {
+        guard !isConfigLoadFailed else { return false }
         guard vpnType != nil else { return false }
         let hasPrimaryVPN = config.routes.contains {
             $0.egress == .vpnDefault
@@ -288,7 +325,8 @@ final class RouteManager: ObservableObject {
         return true
     }
     
-    private func createDailyBackupIfNeeded() {
+    private func createDailyBackupIfNeededThrowing() throws {
+        guard !isConfigLoadFailed else { return }
         let backupURL = configURL.deletingLastPathComponent().appendingPathComponent("config.json.bak")
         
         // Check if backup exists and is less than 24 hours old
@@ -298,12 +336,26 @@ final class RouteManager: ObservableObject {
             return // Backup is recent enough
         }
         
-        // Create/overwrite backup
+        // Create/overwrite backup safely
         if FileManager.default.fileExists(atPath: configURL.path) {
-            try? FileManager.default.removeItem(at: backupURL)
-            try? FileManager.default.copyItem(at: configURL, to: backupURL)
-            // The backup carries the same proxy credentials — restrict it to 0600 too.
-            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: backupURL.path)
+            let dir = configURL.deletingLastPathComponent()
+            let tempBackupURL = dir.appendingPathComponent("config.json.bak.tmp-\(UUID().uuidString)")
+            
+            try FileManager.default.copyItem(at: configURL, to: tempBackupURL)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tempBackupURL.path)
+            
+            let attrs = try FileManager.default.attributesOfItem(atPath: tempBackupURL.path)
+            guard let permissions = attrs[.posixPermissions] as? NSNumber, permissions.uint16Value == 0o600 else {
+                try? FileManager.default.removeItem(at: tempBackupURL)
+                throw NSError(domain: "VPNBypass", code: 1003, userInfo: [NSLocalizedDescriptionKey: "Failed to verify 0600 permissions on temporary backup file"])
+            }
+
+            if FileManager.default.fileExists(atPath: backupURL.path) {
+                _ = try FileManager.default.replaceItemAt(backupURL, withItemAt: tempBackupURL)
+            } else {
+                try FileManager.default.moveItem(at: tempBackupURL, to: backupURL)
+            }
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: backupURL.path)
             log(.info, "Daily config backup created")
         }
     }
@@ -1305,6 +1357,11 @@ final class RouteManager: ObservableObject {
     }
 
     func detectAndApplyRoutesAsync(sendNotification: Bool = false) async {
+        guard !isConfigLoadFailed else {
+            isLoading = false
+            log(.warning, "detectAndApplyRoutesAsync blocked because config.json failed to load")
+            return
+        }
         isLoading = true
         log(.info, "Starting VPN detection and route application...")
         

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -194,7 +194,7 @@ final class RouteManager: ObservableObject {
     /// Preserves the user's enabled/disabled state while updating domains,
     /// ipRanges, and names from the latest source code definitions.
     /// Also adds any new built-in services that didn't exist when the user last saved.
-    private func mergeBuiltInServices() {
+    private func mergeBuiltInServices(autoSave: Bool = true) {
         let defaults = Config.defaultServices
         let savedById = Dictionary(uniqueKeysWithValues: config.services.map { ($0.id, $0) })
         let defaultById = Dictionary(uniqueKeysWithValues: defaults.map { ($0.id, $0) })
@@ -231,12 +231,16 @@ final class RouteManager: ObservableObject {
         
         if updated > 0 || added > 0 {
             config.services = merged
-            saveConfig()
+            if autoSave {
+                saveConfig()
+            }
             if updated > 0 { log(.info, "Updated \(updated) built-in service(s) with latest definitions") }
             if added > 0 { log(.info, "Added \(added) new built-in service(s)") }
         } else if config.services.count != merged.count {
             config.services = merged
-            saveConfig()
+            if autoSave {
+                saveConfig()
+            }
         }
     }
     
@@ -428,7 +432,7 @@ final class RouteManager: ObservableObject {
             let previousLoadFailed = isConfigLoadFailed
 
             config = exportData.config
-            mergeBuiltInServices()
+            mergeBuiltInServices(autoSave: false)
 
             // Perform recovery write using saveConfigThrowing() while temporarily allowing writes
             isConfigLoadFailed = false

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -136,7 +136,7 @@ final class RouteManager: ObservableObject {
     
     // MARK: - Private
     
-    private let configURL: URL
+    let configURL: URL
     private var refreshTimer: Timer?
     
     private init() {
@@ -167,16 +167,23 @@ final class RouteManager: ObservableObject {
         // Load DNS cache for faster startup / fallback
         loadDNSCache()
         
-        guard let data = try? Data(contentsOf: configURL),
-              let loaded = try? JSONDecoder().decode(Config.self, from: data) else {
-            log(.info, "Using default config")
+        guard FileManager.default.fileExists(atPath: configURL.path) else {
+            log(.info, "Config file absent, using default config")
+            config = Config()
             ensurePrimaryVPNRoute()
             return
         }
-        config = loaded
-        ensurePrimaryVPNRoute()
-        mergeBuiltInServices()
-        log(.info, "Config loaded")
+
+        do {
+            let data = try Data(contentsOf: configURL)
+            let loaded = try JSONDecoder().decode(Config.self, from: data)
+            config = loaded
+            ensurePrimaryVPNRoute()
+            mergeBuiltInServices()
+            log(.info, "Config loaded")
+        } catch {
+            log(.error, "Failed to load config from \(configURL.path): \(error.localizedDescription). Preserving file on disk.")
+        }
     }
     
     /// Merge built-in service definitions with the user's saved config.

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -172,6 +172,11 @@ final class RouteManager: ObservableObject {
             isConfigLoadFailed = false
             log(.info, "Config file absent, using default config")
             config = Config()
+            // Config's DECODER is the only place that derives the Direct and primary-VPN
+            // system routes, so a brand-new install — which never decodes anything — had an
+            // empty Rules route picker for its whole first session and only healed on the
+            // next launch. Seed the same two routes here.
+            seedSystemRoutesIfEmpty()
             ensurePrimaryVPNRoute()
             return
         }
@@ -181,12 +186,19 @@ final class RouteManager: ObservableObject {
             let loaded = try JSONDecoder().decode(Config.self, from: data)
             config = loaded
             isConfigLoadFailed = false
+            seedSystemRoutesIfEmpty()
             ensurePrimaryVPNRoute()
             mergeBuiltInServices()
             log(.info, "Config loaded")
         } catch {
             isConfigLoadFailed = true
             log(.error, "Failed to load config from \(configURL.path): \(error.localizedDescription). Preserving file on disk.")
+            // The latch below blocks every save and every route application, so without this
+            // the menu bar shows a healthy app that quietly enforces nothing — the same trap
+            // the helper-not-ready notification exists to close.
+            NotificationManager.shared.notifyEnforcementFailed(
+                reason: String(localized: "Your configuration file could not be read, so no routes are being enforced. It has been left untouched at ~/Library/Application Support/VPNBypass/config.json — repair it, or import a saved configuration from Settings.")
+            )
         }
     }
     
@@ -273,52 +285,55 @@ final class RouteManager: ObservableObject {
             throw NSError(domain: "VPNBypass", code: 1001, userInfo: [NSLocalizedDescriptionKey: "Configuration save blocked due to load failure"])
         }
 
-        // Daily backup - overwrite if older than 24 hours
-        try createDailyBackupIfNeededThrowing()
+        // Daily backup - overwrite if older than 24 hours. Best-effort on purpose: the
+        // backup is a convenience, and letting it fail the save would lose the user's
+        // actual change over a stale copy.
+        do {
+            try createDailyBackupIfNeededThrowing()
+        } catch {
+            log(.warning, "Daily config backup skipped: \(error.localizedDescription)")
+        }
 
         let encoder = JSONEncoder()
         let data = try encoder.encode(config)
 
         let dir = configURL.deletingLastPathComponent()
         let tempURL = dir.appendingPathComponent("config.json.tmp-\(UUID().uuidString)")
+        // Every throw below leaves the temp behind otherwise, and these accumulate in
+        // ~/Library/Application Support/VPNBypass/ forever.
+        defer { try? FileManager.default.removeItem(at: tempURL) }
 
-        // 1. Write data to temporary file
-        try data.write(to: tempURL, options: .atomic)
-
-        // 2. Set strict 0600 owner-only permissions BEFORE replacing target file
-        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tempURL.path)
-
-        // 3. Verify permissions on temporary file
-        let attrs = try FileManager.default.attributesOfItem(atPath: tempURL.path)
-        guard let permissions = attrs[.posixPermissions] as? NSNumber, permissions.uint16Value == 0o600 else {
-            try? FileManager.default.removeItem(at: tempURL)
-            throw NSError(domain: "VPNBypass", code: 1002, userInfo: [NSLocalizedDescriptionKey: "Failed to verify 0600 permissions on temporary config file"])
+        // Create the temp file 0600 in one step. Writing first and chmod'ing after leaves a
+        // window where a file holding localProxySecret and proxy passwords is umask-default
+        // 0644 inside a 0755 directory. `replaceItemAt` then keeps the DESTINATION's mode,
+        // not the source's, so the mode that matters is the one set after the replace.
+        guard FileManager.default.createFile(
+            atPath: tempURL.path, contents: data, attributes: [.posixPermissions: 0o600]
+        ) else {
+            throw NSError(domain: "VPNBypass", code: 1002,
+                          userInfo: [NSLocalizedDescriptionKey: "Could not create the temporary config file"])
         }
 
-        // 4. Atomically replace target configURL with the secured temporary file
         if FileManager.default.fileExists(atPath: configURL.path) {
             _ = try FileManager.default.replaceItemAt(configURL, withItemAt: tempURL)
         } else {
             try FileManager.default.moveItem(at: tempURL, to: configURL)
         }
-
-        // 5. Ensure final destination permissions remain 0600
         try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: configURL.path)
 
         log(.info, "Config saved")
     }
 
-    /// Ensure Rules has a real, persisted route for the currently detected primary VPN.
-    /// A nil selector is already the legacy primary-VPN representation.
+    /// Ensure Rules has a real, persisted route for the primary VPN, the way `Config.derive()`
+    /// already does for every config that has been decoded from disk. A nil selector is the
+    /// legacy representation of the same thing, so an existing "Corporate VPN" counts.
+    ///
+    /// Called only from `loadConfig()`. It used to run from the VPN-status path, which the
+    /// 30s refresh timer drives (VPNBypassApp.swift:289) — so a user who deleted this route
+    /// got it back, plus a config.json write, every half minute with no way to decline.
     @discardableResult
     func ensurePrimaryVPNRoute() -> Bool {
-        let underTests = NSClassFromString("XCTestCase") != nil
-            || ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
-        if !underTests {
-            guard HelperManager.shared.isHelperInstalled else { return false }
-        }
         guard !isConfigLoadFailed else { return false }
-        guard vpnType != nil else { return false }
         let hasPrimaryVPN = config.routes.contains {
             $0.egress == .vpnDefault
                 && ($0.vpnSelector == nil || $0.vpnSelector?.kind == .primary)
@@ -332,6 +347,19 @@ final class RouteManager: ObservableObject {
         ))
         saveConfig()
         return true
+    }
+
+    /// Populate the two auto-created system routes (Direct + the primary VPN) when a config
+    /// has none. Mirrors `Config.derive()`, which only ever runs inside `Config.init(from:)`.
+    private func seedSystemRoutesIfEmpty() {
+        guard config.routes.isEmpty else { return }
+        let derived = Config.derive(
+            domains: config.domains, services: config.services, mode: config.routingMode,
+            inverseDomains: config.inverseDomains, proxy: config.proxyConfig
+        )
+        config.routes = derived.routes
+        config.rules = derived.rules
+        config.defaultRouteId = derived.defaultRouteId
     }
     
     private func createDailyBackupIfNeededThrowing() throws {
@@ -494,7 +522,9 @@ final class RouteManager: ObservableObject {
 
         let directory = configURL.deletingLastPathComponent()
         let rollbackURL = directory.appendingPathComponent("config.json.rollback-\(UUID().uuidString)")
-        let restoredPermissions = permissions ?? 0o600
+        // Never restore a looser mode than we enforce. A config that was somehow 0644 must
+        // come back 0600, the same way every save tightens it (GHSA-gm4h-95p9-9w7v).
+        let restoredPermissions: UInt16 = min(permissions ?? 0o600, 0o600)
 
         try data.write(to: rollbackURL, options: .atomic)
         try fileManager.setAttributes([.posixPermissions: restoredPermissions], ofItemAtPath: rollbackURL.path)
@@ -641,9 +671,6 @@ final class RouteManager: ObservableObject {
         isVPNConnected = connected
         vpnInterface = connected ? interface : nil
         vpnType = connected ? detectedType : nil
-        if connected && HelperManager.shared.isHelperInstalled {
-            ensurePrimaryVPNRoute()
-        }
         let fetchedTailscaleFingerprint = isVPNConnected ? await currentTailscaleSelfFingerprintIfExitNode() : nil
         // Preserve last fingerprint if a single CLI read fails while VPN remains connected.
         let newTailscaleFingerprint = fetchedTailscaleFingerprint ?? (isVPNConnected ? oldTailscaleFingerprint : nil)
@@ -1438,7 +1465,15 @@ final class RouteManager: ObservableObject {
     func detectAndApplyRoutesAsync(sendNotification: Bool = false) async {
         guard !isConfigLoadFailed else {
             isLoading = false
-            log(.warning, "detectAndApplyRoutesAsync blocked because config.json failed to load")
+            log(.warning, "Config failed to load — enforcing nothing, and removing anything this app left behind")
+            // The latch blocks APPLY, never TEARDOWN. This method is the only caller of the
+            // no-VPN startup sweep (:1535), which is what heals a killed previous run's
+            // leftovers — VPN Only's 0.0.0.0/1 + 128.0.0.0/1 catch-alls included. Returning
+            // early here left those in the kernel with nothing able to remove them, so an
+            // unreadable config.json turned a recoverable state into a broken network.
+            if HelperManager.shared.isHelperInstalled {
+                await startupSweepIfNeeded(desired: [])
+            }
             return
         }
         isLoading = true
@@ -1455,9 +1490,6 @@ final class RouteManager: ObservableObject {
         isVPNConnected = connected
         vpnInterface = connected ? interface : nil
         vpnType = connected ? detectedType : nil
-        if connected {
-            ensurePrimaryVPNRoute()
-        }
         
         log(.info, "VPN detection result: connected=\(connected), interface=\(interface ?? "none")")
         

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -14,11 +14,7 @@ final class RouteManager: ObservableObject {
     
     @Published var isVPNConnected = false
     @Published var vpnInterface: String?
-    @Published var vpnType: VPNType? {
-        didSet {
-            ensurePrimaryVPNRoute()
-        }
-    }
+    @Published var vpnType: VPNType?
     @Published var localGateway: String?
     @Published var vpnGateway: String?
     @Published var activeRoutes: [ActiveRoute] = []
@@ -174,9 +170,11 @@ final class RouteManager: ObservableObject {
         guard let data = try? Data(contentsOf: configURL),
               let loaded = try? JSONDecoder().decode(Config.self, from: data) else {
             log(.info, "Using default config")
+            ensurePrimaryVPNRoute()
             return
         }
         config = loaded
+        ensurePrimaryVPNRoute()
         mergeBuiltInServices()
         log(.info, "Config loaded")
     }
@@ -243,11 +241,20 @@ final class RouteManager: ObservableObject {
     }
 
     func saveConfig() {
+        do {
+            try saveConfigThrowing()
+        } catch {
+            log(.error, "Failed to save configuration: \(error.localizedDescription)")
+        }
+    }
+
+    func saveConfigThrowing() throws {
         // Daily backup - overwrite if older than 24 hours
         createDailyBackupIfNeeded()
         
-        guard let data = try? JSONEncoder().encode(config) else { return }
-        try? data.write(to: configURL)
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(config)
+        try data.write(to: configURL, options: .atomic)
         // config.json can hold proxy credentials — keep it owner-only (0600), tightening
         // any pre-existing 0644 file on every save.
         try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: configURL.path)
@@ -256,13 +263,14 @@ final class RouteManager: ObservableObject {
 
     /// Ensure Rules has a real, persisted route for the currently detected primary VPN.
     /// A nil selector is already the legacy primary-VPN representation.
-    private func ensurePrimaryVPNRoute() {
-        guard vpnType != nil else { return }
+    @discardableResult
+    func ensurePrimaryVPNRoute() -> Bool {
+        guard vpnType != nil else { return false }
         let hasPrimaryVPN = config.routes.contains {
             $0.egress == .vpnDefault
                 && ($0.vpnSelector == nil || $0.vpnSelector?.kind == .primary)
         }
-        guard !hasPrimaryVPN else { return }
+        guard !hasPrimaryVPN else { return false }
 
         config.routes.append(Route(
             name: "Primary VPN",
@@ -270,6 +278,7 @@ final class RouteManager: ObservableObject {
             vpnSelector: VPNSelector(kind: .primary)
         ))
         saveConfig()
+        return true
     }
     
     private func createDailyBackupIfNeeded() {
@@ -1303,6 +1312,9 @@ final class RouteManager: ObservableObject {
         isVPNConnected = connected
         vpnInterface = connected ? interface : nil
         vpnType = connected ? detectedType : nil
+        if connected {
+            ensurePrimaryVPNRoute()
+        }
         
         log(.info, "VPN detection result: connected=\(connected), interface=\(interface ?? "none")")
         

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -308,6 +308,11 @@ final class RouteManager: ObservableObject {
     /// A nil selector is already the legacy primary-VPN representation.
     @discardableResult
     func ensurePrimaryVPNRoute() -> Bool {
+        let underTests = NSClassFromString("XCTestCase") != nil
+            || ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+        if !underTests {
+            guard HelperManager.shared.isHelperInstalled else { return false }
+        }
         guard !isConfigLoadFailed else { return false }
         guard vpnType != nil else { return false }
         let hasPrimaryVPN = config.routes.contains {
@@ -419,9 +424,22 @@ final class RouteManager: ObservableObject {
             let exportData = try JSONDecoder().decode(ExportData.self, from: data)
 
             // Merge or replace config, then normalize built-in services
+            let previousConfig = config
+            let previousLoadFailed = isConfigLoadFailed
+
             config = exportData.config
             mergeBuiltInServices()
-            saveConfig()
+
+            // Perform recovery write using saveConfigThrowing() while temporarily allowing writes
+            isConfigLoadFailed = false
+            do {
+                try saveConfigThrowing()
+            } catch {
+                config = previousConfig
+                isConfigLoadFailed = previousLoadFailed
+                log(.error, "Failed to persist imported config: \(error.localizedDescription)")
+                return false
+            }
 
             log(.success, "Config imported: \(exportData.config.domains.count) domains, \(exportData.config.services.filter { $0.enabled }.count) services enabled")
 
@@ -565,6 +583,9 @@ final class RouteManager: ObservableObject {
         isVPNConnected = connected
         vpnInterface = connected ? interface : nil
         vpnType = connected ? detectedType : nil
+        if connected && HelperManager.shared.isHelperInstalled {
+            ensurePrimaryVPNRoute()
+        }
         let fetchedTailscaleFingerprint = isVPNConnected ? await currentTailscaleSelfFingerprintIfExitNode() : nil
         // Preserve last fingerprint if a single CLI read fails while VPN remains connected.
         let newTailscaleFingerprint = fetchedTailscaleFingerprint ?? (isVPNConnected ? oldTailscaleFingerprint : nil)
@@ -583,7 +604,7 @@ final class RouteManager: ObservableObject {
         
         // Auto-apply routes when VPN connects (skip if already applying or recently applied)
         // Also skip if helper is not ready — no point attempting routes that will all fail
-        if isVPNConnected && !wasVPNConnected && config.autoApplyOnVPN && !isLoading && !isApplyingRoutes && HelperManager.shared.isHelperInstalled {
+        if isVPNConnected && !wasVPNConnected && config.autoApplyOnVPN && !isLoading && !isApplyingRoutes && HelperManager.shared.isHelperInstalled && !isConfigLoadFailed {
             // Skip if routes were applied very recently (within 5 seconds) - prevents double-triggering
             if let lastUpdate = lastUpdate, Date().timeIntervalSince(lastUpdate) < 5 {
                 log(.info, "Skipping duplicate route application (applied \(Int(Date().timeIntervalSince(lastUpdate)))s ago)")

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -427,9 +427,19 @@ final class RouteManager: ObservableObject {
             let data = try Data(contentsOf: url)
             let exportData = try JSONDecoder().decode(ExportData.self, from: data)
 
-            // Merge or replace config, then normalize built-in services
+            // Save previous state for transactional rollback
             let previousConfig = config
             let previousLoadFailed = isConfigLoadFailed
+            let previousDiskData: Data?
+            let previousDiskPermissions: UInt16?
+            if FileManager.default.fileExists(atPath: configURL.path) {
+                previousDiskData = try Data(contentsOf: configURL)
+                let attributes = try FileManager.default.attributesOfItem(atPath: configURL.path)
+                previousDiskPermissions = (attributes[.posixPermissions] as? NSNumber)?.uint16Value
+            } else {
+                previousDiskData = nil
+                previousDiskPermissions = nil
+            }
 
             config = exportData.config
             mergeBuiltInServices(autoSave: false)
@@ -439,8 +449,17 @@ final class RouteManager: ObservableObject {
             do {
                 try saveConfigThrowing()
             } catch {
+                // Rollback in-memory state
                 config = previousConfig
                 isConfigLoadFailed = previousLoadFailed
+
+                // Roll back on-disk state, including restoring a previously missing file.
+                do {
+                    try restoreConfigOnDisk(data: previousDiskData, permissions: previousDiskPermissions)
+                } catch {
+                    log(.error, "Failed to restore previous config.json on disk: \(error.localizedDescription)")
+                }
+
                 log(.error, "Failed to persist imported config: \(error.localizedDescription)")
                 return false
             }
@@ -461,6 +480,41 @@ final class RouteManager: ObservableObject {
             log(.error, "Failed to import config: \(error.localizedDescription)")
             return false
         }
+    }
+
+    private func restoreConfigOnDisk(data: Data?, permissions: UInt16?) throws {
+        let fileManager = FileManager.default
+
+        guard let data else {
+            if fileManager.fileExists(atPath: configURL.path) {
+                try fileManager.removeItem(at: configURL)
+            }
+            return
+        }
+
+        let directory = configURL.deletingLastPathComponent()
+        let rollbackURL = directory.appendingPathComponent("config.json.rollback-\(UUID().uuidString)")
+        let restoredPermissions = permissions ?? 0o600
+
+        try data.write(to: rollbackURL, options: .atomic)
+        try fileManager.setAttributes([.posixPermissions: restoredPermissions], ofItemAtPath: rollbackURL.path)
+
+        let attributes = try fileManager.attributesOfItem(atPath: rollbackURL.path)
+        guard let actualPermissions = (attributes[.posixPermissions] as? NSNumber)?.uint16Value,
+              actualPermissions == restoredPermissions else {
+            throw NSError(
+                domain: "VPNBypass",
+                code: 1004,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to verify restored config file permissions"]
+            )
+        }
+
+        if fileManager.fileExists(atPath: configURL.path) {
+            _ = try fileManager.replaceItemAt(configURL, withItemAt: rollbackURL)
+        } else {
+            try fileManager.moveItem(at: rollbackURL, to: configURL)
+        }
+        try fileManager.setAttributes([.posixPermissions: restoredPermissions], ofItemAtPath: configURL.path)
     }
     
     struct ExportData: Codable {

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -14,7 +14,11 @@ final class RouteManager: ObservableObject {
     
     @Published var isVPNConnected = false
     @Published var vpnInterface: String?
-    @Published var vpnType: VPNType?
+    @Published var vpnType: VPNType? {
+        didSet {
+            ensurePrimaryVPNRoute()
+        }
+    }
     @Published var localGateway: String?
     @Published var vpnGateway: String?
     @Published var activeRoutes: [ActiveRoute] = []
@@ -248,6 +252,24 @@ final class RouteManager: ObservableObject {
         // any pre-existing 0644 file on every save.
         try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: configURL.path)
         log(.info, "Config saved")
+    }
+
+    /// Ensure Rules has a real, persisted route for the currently detected primary VPN.
+    /// A nil selector is already the legacy primary-VPN representation.
+    private func ensurePrimaryVPNRoute() {
+        guard vpnType != nil else { return }
+        let hasPrimaryVPN = config.routes.contains {
+            $0.egress == .vpnDefault
+                && ($0.vpnSelector == nil || $0.vpnSelector?.kind == .primary)
+        }
+        guard !hasPrimaryVPN else { return }
+
+        config.routes.append(Route(
+            name: "Primary VPN",
+            egress: .vpnDefault,
+            vpnSelector: VPNSelector(kind: .primary)
+        ))
+        saveConfig()
     }
     
     private func createDailyBackupIfNeeded() {

--- a/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
+++ b/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
@@ -140,7 +140,7 @@ final class PrimaryVPNRouteTests: XCTestCase {
         XCTAssertEqual(currentBackupContent, backupJSON, "existing config.json.bak must remain byte-for-byte unchanged after automatic apply pass")
     }
 
-    func testStatusDrivenVPNConnectPersistsPrimaryVPNRoute() {
+    func testEnsurePrimaryVPNRouteAppendsAndReportsThatItDid() {
         routeManager.config = Config()
         XCTAssertTrue(routeManager.config.routes.isEmpty)
 
@@ -148,7 +148,7 @@ final class PrimaryVPNRouteTests: XCTestCase {
         routeManager.vpnType = .tailscale
         let added = routeManager.ensurePrimaryVPNRoute()
 
-        XCTAssertTrue(added, "Primary VPN route must be added on VPN connect")
+        XCTAssertTrue(added, "a config with no VPN route must get one, and say so")
         XCTAssertEqual(routeManager.config.routes.count, 1)
         XCTAssertEqual(routeManager.config.routes.first?.name, "Primary VPN")
     }
@@ -161,11 +161,18 @@ final class PrimaryVPNRouteTests: XCTestCase {
         let configPerms = (configAttrs[.posixPermissions] as? NSNumber)?.uint16Value
         XCTAssertEqual(configPerms, 0o600, "config.json must have strict 0600 permissions")
 
-        if FileManager.default.fileExists(atPath: backupURL.path) {
-            let backupAttrs = try FileManager.default.attributesOfItem(atPath: backupURL.path)
-            let backupPerms = (backupAttrs[.posixPermissions] as? NSNumber)?.uint16Value
-            XCTAssertEqual(backupPerms, 0o600, "config.json.bak must have strict 0600 permissions")
-        }
+        // Force the backup to exist rather than skipping the assertion when it does not:
+        // wrapped in `if fileExists` this check never ran, so it could not fail. The source
+        // is deliberately 0644 — a backup copied from a loose file inherits that mode, so
+        // dropping the chmod in the backup path turns this red.
+        try Data("{}".utf8).write(to: routeManager.configURL, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: routeManager.configURL.path)
+        try routeManager.saveConfigThrowing()
+        XCTAssertTrue(FileManager.default.fileExists(atPath: backupURL.path),
+                      "a save with an existing config must produce the daily backup")
+        let backupAttrs = try FileManager.default.attributesOfItem(atPath: backupURL.path)
+        XCTAssertEqual((backupAttrs[.posixPermissions] as? NSNumber)?.uint16Value, 0o600,
+                       "config.json.bak carries the same credentials and must be 0600 too")
     }
 
     func testImportConfigRecoversFromConfigLoadFailureAndPersistsToDisk() throws {
@@ -220,5 +227,69 @@ final class PrimaryVPNRouteTests: XCTestCase {
         // 4. Verify disk content remains completely untouched byte-for-byte
         let currentContent = try String(contentsOf: routeManager.configURL, encoding: .utf8)
         XCTAssertEqual(currentContent, invalidJSON, "config.json on disk must remain unchanged on import failure")
+    }
+
+    // MARK: - The production path
+
+    /// The reported gap (#96), reproduced at the level the app actually reaches it. `Config`'s
+    /// DECODER is the only place that derives the Direct + primary-VPN system routes, so a
+    /// brand-new install — which has no config.json to decode — showed an empty route picker
+    /// in Rules for its whole first session. Deleting the seed in `loadConfig()` turns this red.
+    func testFirstLaunchWithNoConfigFileSeedsTheSystemRoutes() {
+        cleanupConfigFiles()
+        routeManager.config = Config()
+        XCTAssertTrue(routeManager.config.routes.isEmpty, "precondition: a default Config has no routes")
+
+        routeManager.loadConfig()
+
+        XCTAssertTrue(routeManager.config.routes.contains { $0.egress == .direct },
+                      "a fresh install must get the Direct system route")
+        XCTAssertTrue(routeManager.config.routes.contains { $0.egress == .vpnDefault && $0.vpnSelector?.kind != .interface },
+                      "a fresh install must get the primary-VPN system route Rules selects")
+    }
+
+    /// A config that decodes but carries no VPN route at all gets one back at load, which is
+    /// the case `ensurePrimaryVPNRoute()` exists for. Deleting its call in `loadConfig()`
+    /// turns this red.
+    func testLoadingAConfigWithNoVPNRouteRestoresThePrimaryVPNRoute() throws {
+        var stored = Config()
+        stored.routes = [Route(name: "Direct", egress: .direct)]
+        try JSONEncoder().encode(stored).write(to: routeManager.configURL, options: .atomic)
+
+        routeManager.config = Config()
+        routeManager.loadConfig()
+
+        XCTAssertEqual(routeManager.config.routes.filter { $0.egress == .vpnDefault }.count, 1,
+                       "exactly one primary-VPN route, not zero and not a duplicate")
+    }
+
+    /// The 30s status timer (VPNBypassApp.swift:289) drives `checkVPNStatus()`. Seeding from
+    /// there re-created a route the user had deliberately deleted, and rewrote config.json,
+    /// every half minute. Seeding is load-time only, so a second pass must be inert.
+    func testSeedingIsIdempotentAndNeverDuplicatesTheRoute() {
+        routeManager.config = Config()
+        routeManager.loadConfig()
+        let afterFirst = routeManager.config.routes.count
+
+        routeManager.loadConfig()
+        routeManager.ensurePrimaryVPNRoute()
+
+        XCTAssertEqual(routeManager.config.routes.count, afterFirst,
+                       "repeat passes must not append another route")
+    }
+
+    /// config.json holds proxy credentials and localProxySecret (GHSA-gm4h-95p9-9w7v). It must
+    /// never exist at umask-default 0644, even briefly, inside a 0755 directory. Note that
+    /// `replaceItemAt` keeps the DESTINATION's mode, so a 0644 file already on disk is the
+    /// case that matters.
+    func testSaveTightensAPreexistingWorldReadableConfig() throws {
+        try Data("{}".utf8).write(to: routeManager.configURL, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: routeManager.configURL.path)
+
+        try routeManager.saveConfigThrowing()
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: routeManager.configURL.path)
+        XCTAssertEqual((attrs[.posixPermissions] as? NSNumber)?.uint16Value, 0o600,
+                       "a save must tighten an existing 0644 config to 0600")
     }
 }

--- a/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
+++ b/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
@@ -6,27 +6,37 @@ final class PrimaryVPNRouteTests: XCTestCase {
 
     private let routeManager = RouteManager.shared
 
+    private var backupURL: URL {
+        routeManager.configURL.deletingLastPathComponent().appendingPathComponent("config.json.bak")
+    }
+
     override func setUp() {
         super.setUp()
+        routeManager.isConfigLoadFailed = false
         routeManager.vpnType = nil
         routeManager.config = Config()
+        cleanupConfigFiles()
     }
 
     override func tearDown() {
+        cleanupConfigFiles()
+        routeManager.isConfigLoadFailed = false
         routeManager.vpnType = nil
         routeManager.config = Config()
         super.tearDown()
     }
 
-    func testDetectedVPNAddsOnePersistedPrimaryRouteAndReloadsFromDisk() {
+    private func cleanupConfigFiles() {
+        try? FileManager.default.removeItem(at: routeManager.configURL)
+        try? FileManager.default.removeItem(at: backupURL)
+    }
+
+    func testDetectedVPNAddsOnePersistedPrimaryRouteAndReloadsFromDisk() throws {
         routeManager.vpnType = .tailscale
         routeManager.ensurePrimaryVPNRoute()
 
         XCTAssertEqual(routeManager.config.routes.count, 1)
-        guard let route = routeManager.config.routes.first else {
-            XCTFail("Expected a primary VPN route in memory")
-            return
-        }
+        let route = try XCTUnwrap(routeManager.config.routes.first, "Expected a primary VPN route in memory")
         XCTAssertEqual(route.egress, .vpnDefault)
         XCTAssertEqual(route.vpnSelector?.kind, .primary)
         XCTAssertEqual(route.name, "Primary VPN")
@@ -40,10 +50,7 @@ final class PrimaryVPNRouteTests: XCTestCase {
         routeManager.loadConfig()
 
         XCTAssertEqual(routeManager.config.routes.count, 1)
-        guard let reloadedRoute = routeManager.config.routes.first else {
-            XCTFail("Expected primary VPN route to be reloaded from disk")
-            return
-        }
+        let reloadedRoute = try XCTUnwrap(routeManager.config.routes.first, "Expected primary VPN route to be reloaded from disk")
         XCTAssertEqual(reloadedRoute.id, savedID)
         XCTAssertEqual(reloadedRoute.egress, .vpnDefault)
         XCTAssertEqual(reloadedRoute.vpnSelector?.kind, .primary)
@@ -80,20 +87,72 @@ final class PrimaryVPNRouteTests: XCTestCase {
         XCTAssertTrue(routeManager.config.routes.isEmpty, "detectVPNStateOnly must be read-only and never mutate config")
     }
 
-    func testLoadConfigPreservesInvalidConfigFileAndBackupOnDisk() {
+    func testLoadConfigPreservesInvalidConfigFileAndBackupOnDisk() throws {
         let invalidJSON = "{ invalid_json_syntax: true "
         let backupJSON = "{ backup_json: true }"
-        let backupURL = routeManager.configURL.deletingLastPathComponent().appendingPathComponent("config.json.bak")
 
-        try? invalidJSON.write(to: routeManager.configURL, atomically: true, encoding: .utf8)
-        try? backupJSON.write(to: backupURL, atomically: true, encoding: .utf8)
+        try invalidJSON.write(to: routeManager.configURL, atomically: true, encoding: .utf8)
+        try backupJSON.write(to: backupURL, atomically: true, encoding: .utf8)
 
         routeManager.loadConfig()
 
-        let currentConfigContent = (try? String(contentsOf: routeManager.configURL, encoding: .utf8)) ?? ""
-        let currentBackupContent = (try? String(contentsOf: backupURL, encoding: .utf8)) ?? ""
+        let currentConfigContent = try String(contentsOf: routeManager.configURL, encoding: .utf8)
+        let currentBackupContent = try String(contentsOf: backupURL, encoding: .utf8)
 
         XCTAssertEqual(currentConfigContent, invalidJSON, "Corrupted config.json must be preserved on disk and not overwritten on load failure")
         XCTAssertEqual(currentBackupContent, backupJSON, "Existing config.json.bak must be preserved on disk and not overwritten on load failure")
+    }
+
+    func testInvalidConfigBlocksAutomaticWritesAndPreservesFiles() async throws {
+        let invalidJSON = "{ invalid_json_syntax: true "
+        let backupJSON = "{ backup_json: true }"
+
+        try invalidJSON.write(to: routeManager.configURL, atomically: true, encoding: .utf8)
+        try backupJSON.write(to: backupURL, atomically: true, encoding: .utf8)
+
+        // 1. loadConfig fails due to invalid JSON
+        routeManager.loadConfig()
+        XCTAssertTrue(routeManager.isConfigLoadFailed, "isConfigLoadFailed state must be active after load failure")
+
+        // 2. Automatic VPN detection and apply path runs with VPN connected
+        routeManager.isVPNConnected = true
+        routeManager.vpnType = .tailscale
+
+        await routeManager.detectAndApplyRoutesAsync()
+
+        // 3. Verify no configuration write occurred and files remain byte-for-byte unchanged
+        let currentConfigContent = try String(contentsOf: routeManager.configURL, encoding: .utf8)
+        let currentBackupContent = try String(contentsOf: backupURL, encoding: .utf8)
+
+        XCTAssertEqual(currentConfigContent, invalidJSON, "invalid config.json must remain byte-for-byte unchanged after automatic apply pass")
+        XCTAssertEqual(currentBackupContent, backupJSON, "existing config.json.bak must remain byte-for-byte unchanged after automatic apply pass")
+    }
+
+    func testStatusDrivenVPNConnectPersistsPrimaryVPNRoute() {
+        routeManager.config = Config()
+        XCTAssertTrue(routeManager.config.routes.isEmpty)
+
+        // Simulate VPN connection detection
+        routeManager.vpnType = .tailscale
+        let added = routeManager.ensurePrimaryVPNRoute()
+
+        XCTAssertTrue(added, "Primary VPN route must be added on VPN connect")
+        XCTAssertEqual(routeManager.config.routes.count, 1)
+        XCTAssertEqual(routeManager.config.routes.first?.name, "Primary VPN")
+    }
+
+    func testSaveConfigSetsStrict0600PermissionsOnConfigAndBackup() throws {
+        routeManager.vpnType = .tailscale
+        try routeManager.saveConfigThrowing()
+
+        let configAttrs = try FileManager.default.attributesOfItem(atPath: routeManager.configURL.path)
+        let configPerms = (configAttrs[.posixPermissions] as? NSNumber)?.uint16Value
+        XCTAssertEqual(configPerms, 0o600, "config.json must have strict 0600 permissions")
+
+        if FileManager.default.fileExists(atPath: backupURL.path) {
+            let backupAttrs = try FileManager.default.attributesOfItem(atPath: backupURL.path)
+            let backupPerms = (backupAttrs[.posixPermissions] as? NSNumber)?.uint16Value
+            XCTAssertEqual(backupPerms, 0o600, "config.json.bak must have strict 0600 permissions")
+        }
     }
 }

--- a/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
+++ b/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
@@ -79,4 +79,21 @@ final class PrimaryVPNRouteTests: XCTestCase {
 
         XCTAssertTrue(routeManager.config.routes.isEmpty, "detectVPNStateOnly must be read-only and never mutate config")
     }
+
+    func testLoadConfigPreservesInvalidConfigFileAndBackupOnDisk() {
+        let invalidJSON = "{ invalid_json_syntax: true "
+        let backupJSON = "{ backup_json: true }"
+        let backupURL = routeManager.configURL.deletingLastPathComponent().appendingPathComponent("config.json.bak")
+
+        try? invalidJSON.write(to: routeManager.configURL, atomically: true, encoding: .utf8)
+        try? backupJSON.write(to: backupURL, atomically: true, encoding: .utf8)
+
+        routeManager.loadConfig()
+
+        let currentConfigContent = (try? String(contentsOf: routeManager.configURL, encoding: .utf8)) ?? ""
+        let currentBackupContent = (try? String(contentsOf: backupURL, encoding: .utf8)) ?? ""
+
+        XCTAssertEqual(currentConfigContent, invalidJSON, "Corrupted config.json must be preserved on disk and not overwritten on load failure")
+        XCTAssertEqual(currentBackupContent, backupJSON, "Existing config.json.bak must be preserved on disk and not overwritten on load failure")
+    }
 }

--- a/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
+++ b/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
@@ -18,24 +18,44 @@ final class PrimaryVPNRouteTests: XCTestCase {
         super.tearDown()
     }
 
-    func testDetectedVPNAddsOnePersistedPrimaryRoute() {
+    func testDetectedVPNAddsOnePersistedPrimaryRouteAndReloadsFromDisk() {
         routeManager.vpnType = .tailscale
+        routeManager.ensurePrimaryVPNRoute()
 
         XCTAssertEqual(routeManager.config.routes.count, 1)
         guard let route = routeManager.config.routes.first else {
-            XCTFail("Expected a primary VPN route")
+            XCTFail("Expected a primary VPN route in memory")
             return
         }
         XCTAssertEqual(route.egress, .vpnDefault)
         XCTAssertEqual(route.vpnSelector?.kind, .primary)
         XCTAssertEqual(route.name, "Primary VPN")
+
+        let savedID = route.id
+
+        // Reset in-memory configuration and reload from disk
+        routeManager.config = Config()
+        XCTAssertTrue(routeManager.config.routes.isEmpty)
+
+        routeManager.loadConfig()
+
+        XCTAssertEqual(routeManager.config.routes.count, 1)
+        guard let reloadedRoute = routeManager.config.routes.first else {
+            XCTFail("Expected primary VPN route to be reloaded from disk")
+            return
+        }
+        XCTAssertEqual(reloadedRoute.id, savedID)
+        XCTAssertEqual(reloadedRoute.egress, .vpnDefault)
+        XCTAssertEqual(reloadedRoute.vpnSelector?.kind, .primary)
     }
 
     func testRepeatedDetectionDoesNotAddDuplicatePrimaryRoutes() {
         routeManager.vpnType = .tailscale
+        routeManager.ensurePrimaryVPNRoute()
         let firstID = routeManager.config.routes.first?.id
 
         routeManager.vpnType = .tailscale
+        routeManager.ensurePrimaryVPNRoute()
 
         XCTAssertEqual(routeManager.config.routes.count, 1)
         XCTAssertEqual(routeManager.config.routes.first?.id, firstID)
@@ -46,7 +66,17 @@ final class PrimaryVPNRouteTests: XCTestCase {
         routeManager.config.routes = [existing]
 
         routeManager.vpnType = .tailscale
+        routeManager.ensurePrimaryVPNRoute()
 
         XCTAssertEqual(routeManager.config.routes, [existing])
+    }
+
+    func testDetectVPNStateOnlyIsReadOnlyAndDoesNotMutateConfig() async {
+        routeManager.config = Config()
+        XCTAssertTrue(routeManager.config.routes.isEmpty)
+
+        await routeManager.detectVPNStateOnly()
+
+        XCTAssertTrue(routeManager.config.routes.isEmpty, "detectVPNStateOnly must be read-only and never mutate config")
     }
 }

--- a/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
+++ b/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import VPNBypassCore
+
+@MainActor
+final class PrimaryVPNRouteTests: XCTestCase {
+
+    private let routeManager = RouteManager.shared
+
+    override func setUp() {
+        super.setUp()
+        routeManager.vpnType = nil
+        routeManager.config = Config()
+    }
+
+    override func tearDown() {
+        routeManager.vpnType = nil
+        routeManager.config = Config()
+        super.tearDown()
+    }
+
+    func testDetectedVPNAddsOnePersistedPrimaryRoute() {
+        routeManager.vpnType = .tailscale
+
+        XCTAssertEqual(routeManager.config.routes.count, 1)
+        guard let route = routeManager.config.routes.first else {
+            XCTFail("Expected a primary VPN route")
+            return
+        }
+        XCTAssertEqual(route.egress, .vpnDefault)
+        XCTAssertEqual(route.vpnSelector?.kind, .primary)
+        XCTAssertEqual(route.name, "Primary VPN")
+    }
+
+    func testRepeatedDetectionDoesNotAddDuplicatePrimaryRoutes() {
+        routeManager.vpnType = .tailscale
+        let firstID = routeManager.config.routes.first?.id
+
+        routeManager.vpnType = .tailscale
+
+        XCTAssertEqual(routeManager.config.routes.count, 1)
+        XCTAssertEqual(routeManager.config.routes.first?.id, firstID)
+    }
+
+    func testLegacyNilSelectorCountsAsExistingPrimaryRoute() {
+        let existing = Route(name: "Corporate VPN", egress: .vpnDefault)
+        routeManager.config.routes = [existing]
+
+        routeManager.vpnType = .tailscale
+
+        XCTAssertEqual(routeManager.config.routes, [existing])
+    }
+}

--- a/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
+++ b/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
@@ -181,8 +181,7 @@ final class PrimaryVPNRouteTests: XCTestCase {
         validConfig.domains = [DomainEntry(domain: "recovered.example.com")]
         let appVersion = try XCTUnwrap(
             (Bundle(for: Self.self).infoDictionary?["CFBundleShortVersionString"] as? String)
-                ?? (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String)
-                ?? "1.0.0",
+                ?? (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String),
             "Expected CFBundleShortVersionString in bundle infoDictionary"
         )
         let exportData = RouteManager.ExportData(version: appVersion, exportDate: Date(), config: validConfig)

--- a/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
+++ b/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
@@ -26,9 +26,21 @@ final class PrimaryVPNRouteTests: XCTestCase {
         super.tearDown()
     }
 
+    private func removeFileIgnoringMissing(_ url: URL) {
+        do {
+            try FileManager.default.removeItem(at: url)
+        } catch {
+            let nsError = error as NSError
+            if nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileNoSuchFileError {
+                return
+            }
+            XCTFail("Failed to clean up test file at \(url.path): \(error.localizedDescription)")
+        }
+    }
+
     private func cleanupConfigFiles() {
-        try? FileManager.default.removeItem(at: routeManager.configURL)
-        try? FileManager.default.removeItem(at: backupURL)
+        removeFileIgnoringMissing(routeManager.configURL)
+        removeFileIgnoringMissing(backupURL)
     }
 
     func testDetectedVPNAddsOnePersistedPrimaryRouteAndReloadsFromDisk() throws {
@@ -154,5 +166,34 @@ final class PrimaryVPNRouteTests: XCTestCase {
             let backupPerms = (backupAttrs[.posixPermissions] as? NSNumber)?.uint16Value
             XCTAssertEqual(backupPerms, 0o600, "config.json.bak must have strict 0600 permissions")
         }
+    }
+
+    func testImportConfigRecoversFromConfigLoadFailureAndPersistsToDisk() throws {
+        let invalidJSON = "{ invalid_json_syntax: true "
+        try invalidJSON.write(to: routeManager.configURL, atomically: true, encoding: .utf8)
+
+        // 1. loadConfig fails
+        routeManager.loadConfig()
+        XCTAssertTrue(routeManager.isConfigLoadFailed, "isConfigLoadFailed state must be active after load failure")
+
+        // 2. Prepare valid export file to import
+        var validConfig = Config()
+        validConfig.domains = [DomainEntry(domain: "recovered.example.com")]
+        let exportData = RouteManager.ExportData(version: "4.7.2", exportDate: Date(), config: validConfig)
+        let exportDataData = try JSONEncoder().encode(exportData)
+
+        let tempExportURL = routeManager.configURL.deletingLastPathComponent().appendingPathComponent("export_test.json")
+        try exportDataData.write(to: tempExportURL, options: .atomic)
+        defer { try? FileManager.default.removeItem(at: tempExportURL) }
+
+        // 3. Perform importConfig
+        let success = routeManager.importConfig(from: tempExportURL)
+        XCTAssertTrue(success, "importConfig must succeed for valid configuration")
+        XCTAssertFalse(routeManager.isConfigLoadFailed, "isConfigLoadFailed must be cleared after successful recovery write")
+
+        // 4. Verify disk content is valid and reloads successfully
+        let reloadedData = try Data(contentsOf: routeManager.configURL)
+        let reloadedConfig = try JSONDecoder().decode(Config.self, from: reloadedData)
+        XCTAssertEqual(reloadedConfig.domains.first?.domain, "recovered.example.com")
     }
 }

--- a/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
+++ b/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
@@ -179,12 +179,18 @@ final class PrimaryVPNRouteTests: XCTestCase {
         // 2. Prepare valid export file to import
         var validConfig = Config()
         validConfig.domains = [DomainEntry(domain: "recovered.example.com")]
-        let exportData = RouteManager.ExportData(version: "4.7.2", exportDate: Date(), config: validConfig)
+        let appVersion = try XCTUnwrap(
+            (Bundle(for: Self.self).infoDictionary?["CFBundleShortVersionString"] as? String)
+                ?? (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String)
+                ?? "1.0.0",
+            "Expected CFBundleShortVersionString in bundle infoDictionary"
+        )
+        let exportData = RouteManager.ExportData(version: appVersion, exportDate: Date(), config: validConfig)
         let exportDataData = try JSONEncoder().encode(exportData)
 
         let tempExportURL = routeManager.configURL.deletingLastPathComponent().appendingPathComponent("export_test.json")
         try exportDataData.write(to: tempExportURL, options: .atomic)
-        defer { try? FileManager.default.removeItem(at: tempExportURL) }
+        defer { removeFileIgnoringMissing(tempExportURL) }
 
         // 3. Perform importConfig
         let success = routeManager.importConfig(from: tempExportURL)
@@ -195,5 +201,25 @@ final class PrimaryVPNRouteTests: XCTestCase {
         let reloadedData = try Data(contentsOf: routeManager.configURL)
         let reloadedConfig = try JSONDecoder().decode(Config.self, from: reloadedData)
         XCTAssertEqual(reloadedConfig.domains.first?.domain, "recovered.example.com")
+    }
+
+    func testImportConfigFailureDoesNotLeavePartiallyWrittenConfigOnDisk() throws {
+        let invalidJSON = "{ invalid_json_syntax: true "
+        try invalidJSON.write(to: routeManager.configURL, atomically: true, encoding: .utf8)
+
+        // 1. loadConfig fails due to invalid JSON
+        routeManager.loadConfig()
+        XCTAssertTrue(routeManager.isConfigLoadFailed)
+
+        // 2. Prepare an invalid export file path or unreadable file for import
+        let nonExistentURL = routeManager.configURL.deletingLastPathComponent().appendingPathComponent("non_existent_export.json")
+
+        // 3. Attempt importConfig from invalid URL
+        let success = routeManager.importConfig(from: nonExistentURL)
+        XCTAssertFalse(success, "importConfig must return false when source file is invalid/missing")
+
+        // 4. Verify disk content remains completely untouched byte-for-byte
+        let currentContent = try String(contentsOf: routeManager.configURL, encoding: .utf8)
+        XCTAssertEqual(currentContent, invalidJSON, "config.json on disk must remain unchanged on import failure")
     }
 }


### PR DESCRIPTION
## Summary

- Persist a route for the detected primary VPN so it can be selected in Rules without manually adding a VPN path.
- Use the existing `primary` VPN selector and preserve the legacy nil-selector representation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- Added `PrimaryVPNRouteTests.swift` covering primary VPN route persistence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically creates and saves a “Primary VPN” route when a VPN is detected and none exists.
  * Recognizes existing primary routes, including legacy routes without an explicit selector.
  * Preserves detected primary VPN routes across configuration reloads.
  * Supports recovering from invalid configuration files by importing a valid configuration.
* **Bug Fixes**
  * Prevents duplicate routes and unintended configuration changes during VPN detection.
  * Preserves configuration and backup files when loading fails.
  * Blocks route updates and saves until an invalid configuration is resolved.
  * Saves configuration files atomically with restricted permissions.
  * Prevents route setup when the required system helper is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->