### PR TITLE
fix: stop Import Config destroying the backup it exists to fall back on

### DIFF
--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -279,8 +279,12 @@ final class RouteManager: ObservableObject {
         }
     }
 
-    func saveConfigThrowing() throws {
-        guard !isConfigLoadFailed else {
+    /// - Parameter recoveringFromLoadFailure: set only by `importConfig`, which is replacing an
+    ///   unreadable config.json. It bypasses the save block WITHOUT clearing the latch, so the
+    ///   daily backup — which copies FROM the on-disk config.json — still skips itself and does
+    ///   not overwrite the last known-good `config.json.bak` with the corruption being escaped.
+    func saveConfigThrowing(recoveringFromLoadFailure: Bool = false) throws {
+        guard recoveringFromLoadFailure || !isConfigLoadFailed else {
             log(.warning, "Config save blocked: config.json failed to load and is preserved on disk")
             throw NSError(domain: "VPNBypass", code: 1001, userInfo: [NSLocalizedDescriptionKey: "Configuration save blocked due to load failure"])
         }
@@ -472,10 +476,13 @@ final class RouteManager: ObservableObject {
             config = exportData.config
             mergeBuiltInServices(autoSave: false)
 
-            // Perform recovery write using saveConfigThrowing() while temporarily allowing writes
-            isConfigLoadFailed = false
+            // Keep the latch SET across the write. Clearing it here to get past the save guard
+            // also defeated the backup guard, so recovering from a corrupt config.json copied
+            // that corruption over config.json.bak — destroying the user's only other copy with
+            // the one action they take to recover. The latch is cleared once the write lands.
             do {
-                try saveConfigThrowing()
+                try saveConfigThrowing(recoveringFromLoadFailure: true)
+                isConfigLoadFailed = false
             } catch {
                 // Rollback in-memory state
                 config = previousConfig

--- a/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
+++ b/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
@@ -335,4 +335,39 @@ final class PrimaryVPNRouteTests: XCTestCase {
                           "recovering from a corrupt config must not copy it over the backup")
         XCTAssertEqual(backupAfter, goodBackup, "the last known-good backup must survive recovery")
     }
+
+    /// The rollback in importConfig had no test at all — `restoreConfigOnDisk` was referenced
+    /// only by its own call site. A read-only config directory makes the recovery write fail
+    /// after the transaction has begun, which is the shape of a disk-full or permission error.
+    /// Both halves must come back: the in-memory config and the file on disk.
+    func testAFailedImportRollsBackMemoryAndLeavesDiskUntouched() throws {
+        let original = #"{"domains":[],"schemaVersion":2}"#
+        try original.write(to: routeManager.configURL, atomically: true, encoding: .utf8)
+        routeManager.loadConfig()
+        let configBefore = routeManager.config
+        let latchBefore = routeManager.isConfigLoadFailed
+
+        var incoming = Config()
+        incoming.domains = [DomainEntry(domain: "should-not-land.example.com")]
+        let export = RouteManager.ExportData(version: "test", exportDate: Date(), config: incoming)
+        let exportURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rollback-import-\(UUID().uuidString).json")
+        try JSONEncoder().encode(export).write(to: exportURL, options: .atomic)
+        defer { removeFileIgnoringMissing(exportURL) }
+
+        // Block writes in the config directory so the recovery write cannot land.
+        let dir = routeManager.configURL.deletingLastPathComponent()
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: dir.path)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path) }
+
+        XCTAssertFalse(routeManager.importConfig(from: exportURL), "the import cannot succeed here")
+
+        XCTAssertEqual(routeManager.config.domains.map(\.domain), configBefore.domains.map(\.domain),
+                       "a failed import must roll the in-memory config back")
+        XCTAssertFalse(routeManager.config.domains.contains { $0.domain == "should-not-land.example.com" },
+                       "the rejected import must not survive in memory")
+        XCTAssertEqual(routeManager.isConfigLoadFailed, latchBefore, "the latch must be restored")
+        XCTAssertEqual(try String(contentsOf: routeManager.configURL, encoding: .utf8), original,
+                       "config.json must be byte-for-byte unchanged after a failed import")
+    }
 }

--- a/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
+++ b/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
@@ -10,8 +10,17 @@ final class PrimaryVPNRouteTests: XCTestCase {
         routeManager.configURL.deletingLastPathComponent().appendingPathComponent("config.json.bak")
     }
 
+    private var savedVPNConnected = false
+    private var savedGateway: String?
+
     override func setUp() {
         super.setUp()
+        // RouteManager is a process-wide singleton and XCTest gives no ordering guarantee
+        // between classes, so anything this class writes must be put back. Leaking
+        // isVPNConnected == true arms the real route-application branch in every class that
+        // runs after, which on a machine with the helper installed writes kernel routes.
+        savedVPNConnected = routeManager.isVPNConnected
+        savedGateway = routeManager.localGateway
         routeManager.isConfigLoadFailed = false
         routeManager.vpnType = nil
         routeManager.config = Config()
@@ -23,6 +32,8 @@ final class PrimaryVPNRouteTests: XCTestCase {
         routeManager.isConfigLoadFailed = false
         routeManager.vpnType = nil
         routeManager.config = Config()
+        routeManager.isVPNConnected = savedVPNConnected
+        routeManager.localGateway = savedGateway
         super.tearDown()
     }
 
@@ -291,5 +302,37 @@ final class PrimaryVPNRouteTests: XCTestCase {
         let attrs = try FileManager.default.attributesOfItem(atPath: routeManager.configURL.path)
         XCTAssertEqual((attrs[.posixPermissions] as? NSNumber)?.uint16Value, 0o600,
                        "a save must tighten an existing 0644 config to 0600")
+    }
+
+    /// Import is the one action a user takes to escape a corrupt config.json. It must not
+    /// destroy config.json.bak on the way — that backup is the only other copy of their
+    /// settings. `createDailyBackupIfNeededThrowing` guards on `isConfigLoadFailed` for
+    /// exactly this reason; clearing the latch to get past the save guard defeats it.
+    func testImportRecoveryDoesNotOverwriteTheBackupWithTheCorruptConfig() throws {
+        let corrupt = "{ invalid_json_syntax: true "
+        let goodBackup = #"{"domains":[],"schemaVersion":2}"#
+        try corrupt.write(to: routeManager.configURL, atomically: true, encoding: .utf8)
+        try goodBackup.write(to: backupURL, atomically: true, encoding: .utf8)
+        // Age the backup past the 24h freshness check so the save path tries to refresh it.
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(-90_000)], ofItemAtPath: backupURL.path)
+
+        routeManager.loadConfig()
+        XCTAssertTrue(routeManager.isConfigLoadFailed, "precondition: the latch is set")
+
+        var recovered = Config()
+        recovered.domains = [DomainEntry(domain: "recovered.example.com")]
+        let export = RouteManager.ExportData(version: "test", exportDate: Date(), config: recovered)
+        let exportURL = routeManager.configURL.deletingLastPathComponent()
+            .appendingPathComponent("import-recovery-test.json")
+        try JSONEncoder().encode(export).write(to: exportURL, options: .atomic)
+        defer { removeFileIgnoringMissing(exportURL) }
+
+        XCTAssertTrue(routeManager.importConfig(from: exportURL), "the import itself must succeed")
+
+        let backupAfter = try String(contentsOf: backupURL, encoding: .utf8)
+        XCTAssertNotEqual(backupAfter, corrupt,
+                          "recovering from a corrupt config must not copy it over the backup")
+        XCTAssertEqual(backupAfter, goodBackup, "the last known-good backup must survive recovery")
     }
 }

--- a/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
+++ b/Tests/VPNBypassTests/PrimaryVPNRouteTests.swift
@@ -49,6 +49,16 @@ final class PrimaryVPNRouteTests: XCTestCase {
         }
     }
 
+    /// The app version as the export path reads it. Hardcoding a version string here would
+    /// drift from the bundle and hide a real mismatch.
+    private func bundleAppVersion() throws -> String {
+        try XCTUnwrap(
+            (Bundle(for: Self.self).infoDictionary?["CFBundleShortVersionString"] as? String)
+                ?? (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String),
+            "Expected CFBundleShortVersionString in bundle infoDictionary"
+        )
+    }
+
     private func cleanupConfigFiles() {
         removeFileIgnoringMissing(routeManager.configURL)
         removeFileIgnoringMissing(backupURL)
@@ -322,7 +332,7 @@ final class PrimaryVPNRouteTests: XCTestCase {
 
         var recovered = Config()
         recovered.domains = [DomainEntry(domain: "recovered.example.com")]
-        let export = RouteManager.ExportData(version: "test", exportDate: Date(), config: recovered)
+        let export = RouteManager.ExportData(version: try bundleAppVersion(), exportDate: Date(), config: recovered)
         let exportURL = routeManager.configURL.deletingLastPathComponent()
             .appendingPathComponent("import-recovery-test.json")
         try JSONEncoder().encode(export).write(to: exportURL, options: .atomic)
@@ -349,7 +359,7 @@ final class PrimaryVPNRouteTests: XCTestCase {
 
         var incoming = Config()
         incoming.domains = [DomainEntry(domain: "should-not-land.example.com")]
-        let export = RouteManager.ExportData(version: "test", exportDate: Date(), config: incoming)
+        let export = RouteManager.ExportData(version: try bundleAppVersion(), exportDate: Date(), config: incoming)
         let exportURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("rollback-import-\(UUID().uuidString).json")
         try JSONEncoder().encode(export).write(to: exportURL, options: .atomic)
@@ -357,8 +367,20 @@ final class PrimaryVPNRouteTests: XCTestCase {
 
         // Block writes in the config directory so the recovery write cannot land.
         let dir = routeManager.configURL.deletingLastPathComponent()
+        let originalMode = try XCTUnwrap(
+            (try FileManager.default.attributesOfItem(atPath: dir.path)[.posixPermissions] as? NSNumber)?.uint16Value,
+            "Expected a posix mode on the config directory"
+        )
         try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: dir.path)
-        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path) }
+        defer {
+            // A leaked 0500 here makes every later test in the process fail to write, so put
+            // back exactly what was there and say so loudly if that is not possible.
+            do {
+                try FileManager.default.setAttributes([.posixPermissions: originalMode], ofItemAtPath: dir.path)
+            } catch {
+                XCTFail("Could not restore the config directory to \(String(originalMode, radix: 8)): \(error.localizedDescription)")
+            }
+        }
 
         XCTAssertFalse(routeManager.importConfig(from: exportURL), "the import cannot succeed here")
 


### PR DESCRIPTION
If your `config.json` is unreadable, Import Config is the way out. It was overwriting `config.json.bak` with the corrupt bytes on the way — so the one action you take to recover destroyed your only other copy of your settings. Shipped in v4.7.3.

`createDailyBackupIfNeededThrowing()` already guards itself with `guard !isConfigLoadFailed` (`RouteManager.swift:366`), and that guard is correct: the backup is copied **from** the on-disk `config.json`, which in that state is the corrupt file. `importConfig` defeated it by clearing the latch at `:476` to get past the save guard, then calling `saveConfigThrowing()` at `:478` — which reaches the backup at `:277` with the flag already false. The stale backup then gets replaced with the corruption.

The rollback path never repaired it either: `restoreConfigOnDisk` only ever touches `configURL`, never the backup. So the loss stood whether the import succeeded or failed.

The write now takes an explicit `recoveringFromLoadFailure` flag and the latch stays set until it lands, so the backup guard does what it was written to do.

## Also: the test suite could write real kernel routes

`PrimaryVPNRouteTests` set `isVPNConnected = true` and never put it back. `RouteManager` is a process-wide singleton and XCTest gives no ordering guarantee between classes, so that flag stayed true for everything that ran afterwards — arming the real route-application branch at `RouteManager.swift:3235`. On a machine with the helper installed and a VPN up, `swift test` could start writing into the live kernel routing table. `RouteManagerIntegrationTests.swift:36` documents the assumption that broke: *"Since isVPNConnected is false in tests, route application branches are skipped."*

`setUp`/`tearDown` now snapshot and restore `isVPNConnected` and `localGateway`, matching what `RemoveAllRoutesRetentionTests` and `ShutdownRaceTests` already do.

## Evidence

The new test is red on `main` and green here:

```
XCTAssertEqual failed: ("{ invalid_json_syntax: true ") is not equal to
("{"domains":[],"schemaVersion":2}") - the last known-good backup must survive recovery
```

Local: 1027 tests, 0 failures.

Found by the adversarial review pass on #97, which finished after that PR had already merged and auto-released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration recovery when the current VPN configuration is corrupted.
  - Preserved the last known-good backup during recovery, preventing corrupted settings from replacing it.
  - Ensured recovery completes reliably even when the backup is more than a day old.
  - Improved handling of failed imports when the configuration location cannot be written, preserving existing settings.

- **Reliability**
  - Improved consistency of VPN connection and gateway state during configuration operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->