### PR TITLE
fix: detect NetBird and every other CGNAT VPN on machines without Tailscale

### DIFF
--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -1358,22 +1358,68 @@ final class RouteManager: ObservableObject {
     ///
     /// That distinction is the entire point. Collapsing the two is what allowed a failed status
     /// query to promote Tailscale's own tunnel to "corporate VPN" (see isCorporateVPNIP).
-    enum CGNATIdentity { case tailscale, notTailscale, undetermined }
+    enum CGNATIdentity: Equatable { case tailscale, notTailscale, undetermined }
+
+    /// Who owns a CGNAT address, decided from the only two things we can observe: whether
+    /// Tailscale is running on this machine at all, and what its status query said if it
+    /// answered.
+    ///
+    /// The third input is the whole point. "The status query did not answer" used to be the
+    /// only negative signal, and it was reached BOTH when Tailscale could not be asked AND
+    /// when there is no Tailscale here to ask — the CLI lookup only tries paths that exist.
+    /// So on a machine with no Tailscale, every 100.64/10 tunnel was declined as
+    /// undetermined, and NetBird / Netmaker / Twingate / self-hosted WireGuard meshes were
+    /// never detected at all (#99).
+    ///
+    /// A machine with no Tailscale process cannot own a Tailscale address. That is a
+    /// definitive answer, not an unknown. When Tailscale IS running and the query still
+    /// could not answer, we keep failing closed exactly as before — claiming another tool's
+    /// tunnel is never the safe default (#61).
+    nonisolated static func classifyCGNAT(
+        tailscaleRunning: Bool,
+        statusAnswered: Bool,
+        statusClaimsAddress: Bool
+    ) -> CGNATIdentity {
+        if statusAnswered { return statusClaimsAddress ? .tailscale : .notTailscale }
+        return tailscaleRunning ? .undetermined : .notTailscale
+    }
 
     private func classifyCGNATAddress(_ ip: String) async -> CGNATIdentity {
-        guard let json = await readTailscaleStatusJSON() else { return .undetermined }
+        let json = await readTailscaleStatusJSON()
+        let claims: Bool = {
+            guard let json else { return false }
+            if let selfStatus = json["Self"] as? [String: Any],
+               let selfIPs = selfStatus["TailscaleIPs"] as? [String],
+               selfIPs.contains(ip) {
+                return true
+            }
+            if let topLevelIPs = json["TailscaleIPs"] as? [String],
+               topLevelIPs.contains(ip) {
+                return true
+            }
+            return false
+        }()
+        // Only pay for the process scan when the status query came back empty — on a machine
+        // with a working Tailscale CLI this costs nothing.
+        let running = json != nil ? true : await isTailscaleProcessRunning()
+        return Self.classifyCGNAT(
+            tailscaleRunning: running, statusAnswered: json != nil, statusClaimsAddress: claims
+        )
+    }
 
-        if let selfStatus = json["Self"] as? [String: Any],
-           let selfIPs = selfStatus["TailscaleIPs"] as? [String],
-           selfIPs.contains(ip) {
-            return .tailscale
+    /// Whether any Tailscale process is live, across all three macOS distributions:
+    /// `tailscaled` (open source / Homebrew), `io.tailscale.ipn.macsys.*` (standalone app)
+    /// and `io.tailscale.ipn.macos.*` (App Store). Deliberately a process check rather than a
+    /// file check: the App Store build ships no CLI at any of `tailscaleCLIPaths`, and a
+    /// leftover CLI can outlive an uninstalled Tailscale. `ps` reports processes owned by
+    /// root without any privilege of our own, which is what makes this workable — every one
+    /// of these daemons runs as uid 0.
+    private func isTailscaleProcessRunning() async -> Bool {
+        guard let result = await runProcessAsync("/bin/ps", arguments: ["-eo", "comm"], timeout: 5.0) else {
+            // Could not look: say yes, so the caller stays on the fail-closed path.
+            return true
         }
-        if let topLevelIPs = json["TailscaleIPs"] as? [String],
-           topLevelIPs.contains(ip) {
-            return .tailscale
-        }
-        // Tailscale answered, and does not claim this address.
-        return .notTailscale
+        return result.output.lowercased().contains("tailscale")
     }
 
     private func isTailscaleIP(_ ip: String) async -> Bool {

--- a/Sources/VPNBypassCore/RouteManager.swift
+++ b/Sources/VPNBypassCore/RouteManager.swift
@@ -1415,11 +1415,20 @@ final class RouteManager: ObservableObject {
     /// root without any privilege of our own, which is what makes this workable — every one
     /// of these daemons runs as uid 0.
     private func isTailscaleProcessRunning() async -> Bool {
-        guard let result = await runProcessAsync("/bin/ps", arguments: ["-eo", "comm"], timeout: 5.0) else {
-            // Could not look: say yes, so the caller stays on the fail-closed path.
-            return true
-        }
-        return result.output.lowercased().contains("tailscale")
+        let result = await runProcessAsync("/bin/ps", arguments: ["-eo", "comm"], timeout: 5.0)
+        return Self.tailscaleAppearsRunning(psOutput: result?.output, psExitCode: result?.exitCode)
+    }
+
+    /// Read a process listing for any sign of Tailscale, failing CLOSED on a bad read.
+    ///
+    /// "ps did not mention Tailscale" is only a negative when ps actually succeeded. A listing
+    /// that was truncated, killed or timed out mentions nothing either, and treating that as
+    /// "Tailscale is absent" would let an unverified CGNAT tunnel — possibly Tailscale's own —
+    /// be adopted as the corporate VPN. So a nil result or a nonzero exit means "could not
+    /// look", which is reported as running and keeps the caller on the undetermined path.
+    nonisolated static func tailscaleAppearsRunning(psOutput: String?, psExitCode: Int32?) -> Bool {
+        guard let psOutput, psExitCode == 0 else { return true }
+        return psOutput.lowercased().contains("tailscale")
     }
 
     private func isTailscaleIP(_ ip: String) async -> Bool {

--- a/Tests/VPNBypassTests/CGNATClassificationTests.swift
+++ b/Tests/VPNBypassTests/CGNATClassificationTests.swift
@@ -1,0 +1,83 @@
+// CGNATClassificationTests.swift
+// Who owns a 100.64/10 address — issue #99.
+//
+// CGNAT is shared ground: Tailscale, NetBird, Netmaker, Twingate, Zscaler and Cloudflare WARP
+// all hand out addresses in it, so the address alone proves nothing. The decision has three
+// inputs, and conflating two of them is what broke NetBird detection: "Tailscale could not
+// answer" and "there is no Tailscale here to ask" are not the same fact.
+
+import XCTest
+@testable import VPNBypassCore
+
+final class CGNATClassificationTests: XCTestCase {
+
+    /// The #99 case. No Tailscale anywhere on the machine, so a CGNAT tunnel belongs to
+    /// something else by elimination — NetBird on utun100, Netmaker, Twingate, a self-hosted
+    /// WireGuard mesh. This used to come back undetermined and the tunnel was dropped, which
+    /// is why "VPN-Bypass does not detect my NetBird connection" was true.
+    func testNoTailscaleOnTheMachineMeansTheAddressIsSomebodyElses() {
+        XCTAssertEqual(
+            RouteManager.classifyCGNAT(tailscaleRunning: false, statusAnswered: false, statusClaimsAddress: false),
+            .notTailscale,
+            "with no Tailscale process, no CGNAT address here can be Tailscale's"
+        )
+    }
+
+    /// The #61 safety property, unchanged: Tailscale is up but its status query failed or timed
+    /// out, so we genuinely do not know. Claiming another tool's tunnel is never the safe
+    /// default — this must stay undetermined, which the caller treats as "not the VPN".
+    func testTailscaleRunningButSilentStaysUndetermined() {
+        XCTAssertEqual(
+            RouteManager.classifyCGNAT(tailscaleRunning: true, statusAnswered: false, statusClaimsAddress: false),
+            .undetermined,
+            "a running Tailscale that cannot be queried must still fail closed"
+        )
+    }
+
+    /// Tailscale answered and claims the address: it is Tailscale's, whatever else is running.
+    func testTailscaleClaimingTheAddressWins() {
+        XCTAssertEqual(
+            RouteManager.classifyCGNAT(tailscaleRunning: true, statusAnswered: true, statusClaimsAddress: true),
+            .tailscale
+        )
+    }
+
+    /// Tailscale answered and disclaims the address — a different CGNAT VPN really is the
+    /// tunnel. This is the pre-existing happy path and must not change.
+    func testTailscaleDisclaimingTheAddressMeansAnotherVPN() {
+        XCTAssertEqual(
+            RouteManager.classifyCGNAT(tailscaleRunning: true, statusAnswered: true, statusClaimsAddress: false),
+            .notTailscale
+        )
+    }
+
+    /// An authoritative answer outranks process presence in both directions, so a stale or
+    /// mis-scraped process list can never override what Tailscale itself said.
+    func testAnAnswerAlwaysOutranksProcessPresence() {
+        XCTAssertEqual(
+            RouteManager.classifyCGNAT(tailscaleRunning: false, statusAnswered: true, statusClaimsAddress: true),
+            .tailscale,
+            "if Tailscale claims the address it is Tailscale's, however the process scan read"
+        )
+        XCTAssertEqual(
+            RouteManager.classifyCGNAT(tailscaleRunning: false, statusAnswered: true, statusClaimsAddress: false),
+            .notTailscale
+        )
+    }
+
+    /// Every combination is decided; none falls through to a surprise default.
+    func testTheDecisionTableIsTotal() {
+        for running in [true, false] {
+            for answered in [true, false] {
+                for claims in [true, false] {
+                    let got = RouteManager.classifyCGNAT(
+                        tailscaleRunning: running, statusAnswered: answered, statusClaimsAddress: claims)
+                    let want: RouteManager.CGNATIdentity =
+                        answered ? (claims ? .tailscale : .notTailscale)
+                                 : (running ? .undetermined : .notTailscale)
+                    XCTAssertEqual(got, want, "running=\(running) answered=\(answered) claims=\(claims)")
+                }
+            }
+        }
+    }
+}

--- a/Tests/VPNBypassTests/CGNATClassificationTests.swift
+++ b/Tests/VPNBypassTests/CGNATClassificationTests.swift
@@ -80,4 +80,46 @@ final class CGNATClassificationTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - Reading the process list
+
+    /// The listing has to have succeeded before its silence means anything.
+    func testASuccessfulListingWithoutTailscaleMeansAbsent() {
+        XCTAssertFalse(RouteManager.tailscaleAppearsRunning(
+            psOutput: "/sbin/launchd\n/usr/sbin/netbird\n", psExitCode: 0))
+    }
+
+    func testASuccessfulListingNamingAnyTailscaleVariantMeansPresent() {
+        for comm in [
+            "/usr/local/bin/tailscaled",
+            "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+            "/Library/SystemExtensions/X/io.tailscale.ipn.macsys.network-extension",
+            "/Library/SystemExtensions/X/io.tailscale.ipn.macos.network-extension",
+        ] {
+            XCTAssertTrue(RouteManager.tailscaleAppearsRunning(psOutput: "/sbin/launchd\n\(comm)\n", psExitCode: 0),
+                          "\(comm) must read as Tailscale present")
+        }
+    }
+
+    /// A truncated or killed `ps` mentions Tailscale no more than an honest absence does.
+    /// Reading that as "absent" would adopt an unverified CGNAT tunnel — possibly Tailscale's
+    /// own — as the corporate VPN, which is the failure #61 exists to prevent.
+    func testAFailedListingIsNotEvidenceOfAbsence() {
+        XCTAssertTrue(RouteManager.tailscaleAppearsRunning(psOutput: "", psExitCode: 1),
+                      "a nonzero exit means we could not look, not that Tailscale is gone")
+        XCTAssertTrue(RouteManager.tailscaleAppearsRunning(psOutput: "/sbin/launchd\n", psExitCode: 137),
+                      "a killed ps must not be read as a clean negative")
+        XCTAssertTrue(RouteManager.tailscaleAppearsRunning(psOutput: nil, psExitCode: nil),
+                      "no result at all must fail closed")
+    }
+
+    /// The two halves compose: a failed listing keeps the address undetermined rather than
+    /// handing it to the corporate-VPN path.
+    func testAFailedListingLeavesTheAddressUndetermined() {
+        let running = RouteManager.tailscaleAppearsRunning(psOutput: nil, psExitCode: nil)
+        XCTAssertEqual(
+            RouteManager.classifyCGNAT(tailscaleRunning: running, statusAnswered: false, statusClaimsAddress: false),
+            .undetermined
+        )
+    }
 }


### PR DESCRIPTION
Closes #99.

@smailpouri reported that VPN-Bypass does not detect an active NetBird connection. It turned out not to be missing NetBird support — it is a gate that declines *every* CGNAT VPN on a machine that does not have Tailscale installed.

## What actually happens

NetBird's `100.110.x.x` sits in CGNAT `100.64.0.0/10`, which is contested ground — Tailscale, NetBird, Netmaker, Twingate, Zscaler and Cloudflare WARP all hand out addresses there. So an address alone proves nothing and we ask Tailscale whether it owns it:

```
isCorporateVPNIP          RouteManager.swift:1276   CGNAT → classifyCGNATAddress
classifyCGNATAddress      :1364   guard let json = readTailscaleStatusJSON() else { .undetermined }
readTailscaleStatusJSON   :1422   for path in tailscaleCLIPaths where fileExists(path)
```

That loop only tries paths that **exist**. With no Tailscale installed it never runs, returns `nil`, and `.undetermined` makes `isCorporateVPNIP` return false (`:1300-1302`). The candidate then carries `isCorporateAddress: false` and `VPNInterfaceSelector.select` drops it (`HelperProtocol.swift:342`):

```swift
$0.isUp && $0.isTunnel && $0.isCorporateAddress && !$0.isTailscale
```

So the tunnel is never selected and no VPN is detected.

## The fix

"Tailscale could not answer" and "there is no Tailscale here to ask" are not the same fact. A machine with no Tailscale process cannot own a Tailscale address — that is a definitive answer, not an unknown.

The decision now takes three inputs and is a pure static with its full truth table under test:

| Tailscale running | status answered | verdict |
|---|---|---|
| — | yes, claims it | `.tailscale` |
| — | yes, disclaims it | `.notTailscale` |
| yes | no | `.undetermined` — unchanged, still fails closed (#61) |
| no | no | `.notTailscale` — **the fix** |

Presence is a **process** check, not a file check, and that distinction matters twice: the App Store build ships no CLI at any path we probe, and a leftover CLI can outlive an uninstalled Tailscale. `ps` reports root-owned processes without any privilege of our own, which is what makes this workable — every one of these daemons runs as uid 0. The scan runs only when the status query came back empty, so a machine with a working Tailscale CLI pays nothing.

Substring `tailscale` covers all three macOS distributions: `tailscaled` (open source / Homebrew), `io.tailscale.ipn.macsys.*` (standalone) and `io.tailscale.ipn.macos.*` (App Store).

## Why not the approach in the issue

The issue proposes detecting the `netbird` daemon process. That cannot work here: `hintType` is consumed once, at `RouteManager.swift:1056`, *after* selection has already succeeded — it only names the VPN, and has no influence on eligibility. It would also mean a new vendor every time someone ships a mesh VPN; this fixes the whole class.

## Evidence

Reverting the decision to the old two-state behaviour turns three tests red:

```
("undetermined") is not equal to ("notTailscale") - with no Tailscale process,
no CGNAT address here can be Tailscale's
```

1034 tests, 0 failures locally.

**Not reproduced end to end.** I have no machine with NetBird and no Tailscale — the reporter's exact configuration. The chain above is verified by reading the code and by the CGNAT arithmetic, and the decision table is directly under test, but I would like @smailpouri to confirm on the real setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved classification of corporate VPN connections using CGNAT address ranges.
  - VPN connections are handled correctly when Tailscale is unavailable, not installed, or not running.
  - Preserved fail-closed behavior when system process information cannot be retrieved.
  - Tailscale status continues to take precedence when determining address ownership.

- **Tests**
  - Added coverage for Tailscale detection, supported executable variants, unavailable process listings, and address ownership scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->